### PR TITLE
Implement minimal read query APIs

### DIFF
--- a/db/migrations/postgres/000010_read_query_indexes_and_timestamptz.down.sql
+++ b/db/migrations/postgres/000010_read_query_indexes_and_timestamptz.down.sql
@@ -1,0 +1,27 @@
+DROP INDEX IF EXISTS idx_publish_jobs_user_status_effective_id;
+DROP INDEX IF EXISTS idx_publish_jobs_user_effective_id;
+DROP INDEX IF EXISTS idx_publish_jobs_topic_status_effective_id;
+DROP INDEX IF EXISTS idx_publish_jobs_topic_effective_id;
+DROP INDEX IF EXISTS idx_user_topic_subscriptions_user_topic_created;
+DROP INDEX IF EXISTS idx_user_topic_subscriptions_topic_created_user;
+DROP INDEX IF EXISTS idx_users_created_id;
+
+ALTER TABLE delivery_receipts
+    ALTER COLUMN dispatched_at TYPE TEXT
+    USING dispatched_at::text;
+
+ALTER TABLE publish_jobs
+    ALTER COLUMN created_at TYPE TEXT
+    USING created_at::text;
+
+ALTER TABLE user_topic_subscriptions
+    ALTER COLUMN created_at TYPE TEXT
+    USING created_at::text;
+
+ALTER TABLE tokens
+    ALTER COLUMN created_at TYPE TEXT
+    USING created_at::text;
+
+ALTER TABLE users
+    ALTER COLUMN created_at TYPE TEXT
+    USING created_at::text;

--- a/db/migrations/postgres/000010_read_query_indexes_and_timestamptz.up.sql
+++ b/db/migrations/postgres/000010_read_query_indexes_and_timestamptz.up.sql
@@ -1,0 +1,44 @@
+ALTER TABLE users
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at::timestamptz;
+
+ALTER TABLE tokens
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at::timestamptz;
+
+ALTER TABLE user_topic_subscriptions
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at::timestamptz;
+
+ALTER TABLE publish_jobs
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ
+    USING created_at::timestamptz;
+
+ALTER TABLE delivery_receipts
+    ALTER COLUMN dispatched_at TYPE TIMESTAMPTZ
+    USING dispatched_at::timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_users_created_id
+    ON users(created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_user_topic_subscriptions_topic_created_user
+    ON user_topic_subscriptions(topic_id, created_at DESC, user_id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_user_topic_subscriptions_user_topic_created
+    ON user_topic_subscriptions(user_id, topic_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_publish_jobs_topic_effective_id
+    ON publish_jobs(topic_id, COALESCE(scheduled_at, created_at) DESC, id DESC)
+    WHERE topic_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_publish_jobs_topic_status_effective_id
+    ON publish_jobs(topic_id, status, COALESCE(scheduled_at, created_at) DESC, id DESC)
+    WHERE topic_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_publish_jobs_user_effective_id
+    ON publish_jobs(user_id, COALESCE(scheduled_at, created_at) DESC, id DESC)
+    WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_publish_jobs_user_status_effective_id
+    ON publish_jobs(user_id, status, COALESCE(scheduled_at, created_at) DESC, id DESC)
+    WHERE user_id IS NOT NULL;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -37,6 +37,25 @@ paths:
                 type: string
                 example: pong
 
+  /v1/users:
+    get:
+      tags: [Users]
+      summary: List users
+      parameters:
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Users ordered by creation time descending.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedUsers"
+        "400":
+          $ref: "#/components/responses/TextError"
+        "500":
+          $ref: "#/components/responses/TextError"
+
   /v1/users/:
     post:
       tags: [Users]
@@ -203,6 +222,31 @@ paths:
         "500":
           $ref: "#/components/responses/TextError"
 
+  /v1/users/{userID}/notifications:
+    parameters:
+      - $ref: "#/components/parameters/UserID"
+    get:
+      tags: [Notifications]
+      summary: List notifications eligible for a user
+      description: Returns direct user sends and topic sends where the user is currently subscribed and the job effective time is on or after the subscription time. This is eligibility, not delivery history.
+      parameters:
+        - $ref: "#/components/parameters/NotificationStatus"
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Eligible notification jobs ordered by effective time descending.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedPublishJobs"
+        "400":
+          $ref: "#/components/responses/TextError"
+        "404":
+          $ref: "#/components/responses/TextError"
+        "500":
+          $ref: "#/components/responses/TextError"
+
   /v1/users/{userID}/send:
     parameters:
       - $ref: "#/components/parameters/UserID"
@@ -318,6 +362,53 @@ paths:
         "500":
           $ref: "#/components/responses/TextError"
 
+  /v1/topics/{topicID}/subscribers:
+    parameters:
+      - $ref: "#/components/parameters/TopicID"
+    get:
+      tags: [Subscriptions]
+      summary: List topic subscribers
+      parameters:
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Current subscribers ordered by subscription time descending.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedTopicSubscribers"
+        "400":
+          $ref: "#/components/responses/TextError"
+        "404":
+          $ref: "#/components/responses/TextError"
+        "500":
+          $ref: "#/components/responses/TextError"
+
+  /v1/topics/{topicID}/notifications:
+    parameters:
+      - $ref: "#/components/parameters/TopicID"
+    get:
+      tags: [Notifications]
+      summary: List notifications for a topic
+      parameters:
+        - $ref: "#/components/parameters/NotificationStatus"
+        - $ref: "#/components/parameters/Cursor"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Topic notification jobs ordered by effective time descending.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedPublishJobs"
+        "400":
+          $ref: "#/components/responses/TextError"
+        "404":
+          $ref: "#/components/responses/TextError"
+        "500":
+          $ref: "#/components/responses/TextError"
+
   /v1/topics/{topicID}/publish:
     parameters:
       - $ref: "#/components/parameters/TopicID"
@@ -346,17 +437,15 @@ paths:
         "503":
           $ref: "#/components/responses/TextError"
 
-  /v1/topics/{topicID}/publish/{jobID}:
+  /v1/notifications/{jobID}:
     parameters:
-      - $ref: "#/components/parameters/TopicID"
       - $ref: "#/components/parameters/JobID"
     get:
       tags: [Notifications]
-      summary: Get publish job status
-      description: The current handler looks up by jobID; topicID is not used for filtering.
+      summary: Get notification job
       responses:
         "200":
-          description: Job status.
+          description: Notification job.
           content:
             application/json:
               schema:
@@ -519,6 +608,31 @@ components:
       schema:
         type: string
       example: 018f7b7a-a9b7-7a22-9d6f-6fb3c9b6b9c0
+    Cursor:
+      name: cursor
+      in: query
+      required: false
+      description: Opaque URL-safe cursor returned by the previous page.
+      schema:
+        type: string
+    Limit:
+      name: limit
+      in: query
+      required: false
+      description: Page size. Defaults to 50 and must be between 1 and 200.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+    NotificationStatus:
+      name: status
+      in: query
+      required: false
+      description: Exact uppercase notification job status. Omit for no status filter.
+      schema:
+        type: string
+        enum: [QUEUED, SCHEDULED, IN_PROGRESS, DISPATCHED, COMPLETED, FAILED]
 
   responses:
     TextError:
@@ -658,6 +772,21 @@ components:
           type: string
           example: "2026-05-01T10:30:00Z"
 
+    PaginatedUsers:
+      type: object
+      required: [items, next_cursor, has_more]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+        next_cursor:
+          type: string
+          example: ""
+        has_more:
+          type: boolean
+          example: false
+
     Token:
       type: object
       required: [ID, UserID, Platform, Token, CreatedAt]
@@ -697,6 +826,35 @@ components:
         CreatedAt:
           type: string
 
+    TopicSubscriber:
+      type: object
+      required: [ID, CreatedAt, SubscribedAt]
+      properties:
+        ID:
+          type: string
+          example: user-123
+        CreatedAt:
+          type: string
+          example: "2026-05-01T10:00:00Z"
+        SubscribedAt:
+          type: string
+          example: "2026-05-01T10:30:00Z"
+
+    PaginatedTopicSubscribers:
+      type: object
+      required: [items, next_cursor, has_more]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/TopicSubscriber"
+        next_cursor:
+          type: string
+          example: ""
+        has_more:
+          type: boolean
+          example: false
+
     PublishJob:
       type: object
       required: [ID, Status, TotalCount, SuccessCount, FailureCount, CreatedAt]
@@ -711,7 +869,7 @@ components:
           $ref: "#/components/schemas/NotificationPayload"
         Status:
           type: string
-          enum: [QUEUED, SCHEDULED, IN_PROGRESS, COMPLETED, FAILED]
+          enum: [QUEUED, SCHEDULED, IN_PROGRESS, DISPATCHED, COMPLETED, FAILED]
         TotalCount:
           type: integer
         SuccessCount:
@@ -724,6 +882,21 @@ components:
           type: string
         ScheduledAt:
           type: string
+
+    PaginatedPublishJobs:
+      type: object
+      required: [items, next_cursor, has_more]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublishJob"
+        next_cursor:
+          type: string
+          example: ""
+        has_more:
+          type: boolean
+          example: false
 
     LiveActivityTokenType:
       type: string

--- a/internal/model/push.go
+++ b/internal/model/push.go
@@ -9,6 +9,17 @@ const (
 	FCM  Platform = "fcm"
 )
 
+type NotificationJobStatus string
+
+const (
+	NotificationJobStatusQueued     NotificationJobStatus = "QUEUED"
+	NotificationJobStatusScheduled  NotificationJobStatus = "SCHEDULED"
+	NotificationJobStatusInProgress NotificationJobStatus = "IN_PROGRESS"
+	NotificationJobStatusDispatched NotificationJobStatus = "DISPATCHED"
+	NotificationJobStatusCompleted  NotificationJobStatus = "COMPLETED"
+	NotificationJobStatusFailed     NotificationJobStatus = "FAILED"
+)
+
 type NotificationPayload struct {
 	// Required fields
 	Title string `json:"title"`
@@ -41,5 +52,19 @@ func ParsePlatform(s string) (Platform, error) {
 		return Platform(s), nil
 	default:
 		return "", fmt.Errorf("invalid platform: %q", s)
+	}
+}
+
+func ParseNotificationJobStatus(s string) (NotificationJobStatus, error) {
+	switch NotificationJobStatus(s) {
+	case NotificationJobStatusQueued,
+		NotificationJobStatusScheduled,
+		NotificationJobStatusInProgress,
+		NotificationJobStatusDispatched,
+		NotificationJobStatusCompleted,
+		NotificationJobStatusFailed:
+		return NotificationJobStatus(s), nil
+	default:
+		return "", fmt.Errorf("invalid notification job status: %q", s)
 	}
 }

--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -9,11 +9,11 @@ const (
 	JobTypeLA   JobType = "la"
 )
 
-type Status string
+type DeliveryStatus string
 
 const (
-	Failed  Status = "FAILED"
-	Success Status = "SUCCESS"
+	DeliveryStatusFailed  DeliveryStatus = "FAILED"
+	DeliveryStatusSuccess DeliveryStatus = "SUCCESS"
 )
 
 type SendTarget struct {
@@ -55,7 +55,7 @@ type DeliveryReceipt struct {
 	ID           string
 	JobID        string
 	TokenID      string
-	Status       string
+	Status       DeliveryStatus
 	StatusReason string
 	DispatchedAt string
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -77,7 +77,7 @@ func (s *Scheduler) processScheduledJobs(ctx context.Context) {
 			statusCtx, statusCancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer statusCancel()
 
-			if updateErr := s.store.UpdateJobStatus(statusCtx, jobItem.ID, "FAILED"); updateErr != nil {
+			if updateErr := s.store.UpdateJobStatus(statusCtx, jobItem.ID, model.NotificationJobStatusFailed); updateErr != nil {
 				log.Printf("Failed to mark job %s as FAILED after enqueue error: %v", jobItem.ID, updateErr)
 			}
 		}

--- a/internal/server/pagination.go
+++ b/internal/server/pagination.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/mithileshchellappan/pushboy/internal/model"
+	"github.com/mithileshchellappan/pushboy/internal/storage"
+)
+
+const (
+	defaultPageLimit = 50
+	maxPageLimit     = 200
+	cursorVersion    = 1
+)
+
+type listResponse[T any] struct {
+	Items      []T    `json:"items"`
+	NextCursor string `json:"next_cursor"`
+	HasMore    bool   `json:"has_more"`
+}
+
+type pageCursor struct {
+	Version   int    `json:"v"`
+	Route     string `json:"route"`
+	Status    string `json:"status,omitempty"`
+	SortValue string `json:"sort_value"`
+	ID        string `json:"id"`
+}
+
+func parseLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultPageLimit, nil
+	}
+
+	limit, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, err
+	}
+	if limit <= 0 || limit > maxPageLimit {
+		return 0, errors.New("limit out of range")
+	}
+
+	return limit, nil
+}
+
+func parseNotificationStatus(raw string) (model.NotificationJobStatus, error) {
+	if raw == "" {
+		return "", nil
+	}
+	return model.ParseNotificationJobStatus(raw)
+}
+
+func parseCursor(raw string, route string, status model.NotificationJobStatus) (storage.PageCursor, error) {
+	if raw == "" {
+		return storage.PageCursor{}, nil
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return storage.PageCursor{}, err
+	}
+
+	var cursor pageCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil {
+		return storage.PageCursor{}, err
+	}
+
+	if cursor.Version != cursorVersion || cursor.Route != route || cursor.Status != string(status) || cursor.SortValue == "" || cursor.ID == "" {
+		return storage.PageCursor{}, errors.New("invalid cursor")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, cursor.SortValue); err != nil {
+		return storage.PageCursor{}, err
+	}
+
+	return storage.PageCursor{
+		SortValue: cursor.SortValue,
+		ID:        cursor.ID,
+	}, nil
+}
+
+func encodeCursor(route string, status model.NotificationJobStatus, sortValue string, id string) string {
+	payload, err := json.Marshal(pageCursor{
+		Version:   cursorVersion,
+		Route:     route,
+		Status:    string(status),
+		SortValue: sortValue,
+		ID:        id,
+	})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func pageQueryFromRequest(r *http.Request, route string) (storage.PageQuery, int, error) {
+	limit, err := parseLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		return storage.PageQuery{}, 0, err
+	}
+
+	cursor, err := parseCursor(r.URL.Query().Get("cursor"), route, "")
+	if err != nil {
+		return storage.PageQuery{}, 0, err
+	}
+
+	return storage.PageQuery{
+		Limit:  limit + 1,
+		Cursor: cursor,
+	}, limit, nil
+}
+
+func notificationListQueryFromRequest(r *http.Request, route string) (storage.NotificationListQuery, int, error) {
+	status, err := parseNotificationStatus(r.URL.Query().Get("status"))
+	if err != nil {
+		return storage.NotificationListQuery{}, 0, err
+	}
+
+	limit, err := parseLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		return storage.NotificationListQuery{}, 0, err
+	}
+
+	cursor, err := parseCursor(r.URL.Query().Get("cursor"), route, status)
+	if err != nil {
+		return storage.NotificationListQuery{}, 0, err
+	}
+
+	return storage.NotificationListQuery{
+		Limit:  limit + 1,
+		Cursor: cursor,
+		Status: status,
+	}, limit, nil
+}
+
+func notificationJobCursorTime(job storage.PublishJob) string {
+	if job.ScheduledAt != "" {
+		return job.ScheduledAt
+	}
+	return job.CreatedAt
+}
+
+func makeListResponse[T any](items []T, limit int, route string, status model.NotificationJobStatus, keyFunc func(T) (string, string)) listResponse[T] {
+	if items == nil {
+		items = make([]T, 0)
+	}
+
+	response := listResponse[T]{
+		Items: items,
+	}
+
+	if len(items) <= limit {
+		return response
+	}
+
+	response.HasMore = true
+	response.Items = items[:limit]
+	sortValue, id := keyFunc(response.Items[len(response.Items)-1])
+	response.NextCursor = encodeCursor(route, status, sortValue, id)
+	return response
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,12 +2,10 @@ package server
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,35 +25,6 @@ type Server struct {
 }
 
 const immediateEnqueueTimeout = 2 * time.Second
-
-const (
-	defaultPageLimit = 50
-	maxPageLimit     = 200
-	cursorVersion    = 1
-)
-
-var validNotificationStatuses = map[string]struct{}{
-	"QUEUED":      {},
-	"SCHEDULED":   {},
-	"IN_PROGRESS": {},
-	"DISPATCHED":  {},
-	"COMPLETED":   {},
-	"FAILED":      {},
-}
-
-type listResponse[T any] struct {
-	Items      []T    `json:"items"`
-	NextCursor string `json:"next_cursor"`
-	HasMore    bool   `json:"has_more"`
-}
-
-type pageCursor struct {
-	Version   int    `json:"v"`
-	Route     string `json:"route"`
-	Status    string `json:"status,omitempty"`
-	SortValue string `json:"sort_value"`
-	ID        string `json:"id"`
-}
 
 func New(s *service.PushboyService, jobPipeline pipeline.Pipeline[model.JobItem]) *Server {
 	return &Server{service: s, jobPipeline: jobPipeline}
@@ -142,148 +111,13 @@ func (s *Server) enqueueImmediateJob(jobID string, jobItem model.JobItem) error 
 		statusCtx, statusCancel := context.WithTimeout(context.Background(), immediateEnqueueTimeout)
 		defer statusCancel()
 
-		if updateErr := s.service.UpdateJobStatus(statusCtx, jobID, "FAILED"); updateErr != nil {
+		if updateErr := s.service.UpdateJobStatus(statusCtx, jobID, model.NotificationJobStatusFailed); updateErr != nil {
 			log.Printf("Failed to mark job %s as FAILED after enqueue error: %v", jobID, updateErr)
 		}
 		return err
 	}
 
 	return nil
-}
-
-func parseLimit(raw string) (int, error) {
-	if raw == "" {
-		return defaultPageLimit, nil
-	}
-
-	limit, err := strconv.Atoi(raw)
-	if err != nil {
-		return 0, err
-	}
-	if limit <= 0 || limit > maxPageLimit {
-		return 0, errors.New("limit out of range")
-	}
-
-	return limit, nil
-}
-
-func parseNotificationStatus(raw string) (string, error) {
-	if raw == "" {
-		return "", nil
-	}
-	if _, ok := validNotificationStatuses[raw]; !ok {
-		return "", errors.New("invalid status")
-	}
-	return raw, nil
-}
-
-func parseCursor(raw string, route string, status string) (storage.PageCursor, error) {
-	if raw == "" {
-		return storage.PageCursor{}, nil
-	}
-
-	payload, err := base64.RawURLEncoding.DecodeString(raw)
-	if err != nil {
-		return storage.PageCursor{}, err
-	}
-
-	var cursor pageCursor
-	if err := json.Unmarshal(payload, &cursor); err != nil {
-		return storage.PageCursor{}, err
-	}
-
-	if cursor.Version != cursorVersion || cursor.Route != route || cursor.Status != status || cursor.SortValue == "" || cursor.ID == "" {
-		return storage.PageCursor{}, errors.New("invalid cursor")
-	}
-	if _, err := time.Parse(time.RFC3339, cursor.SortValue); err != nil {
-		return storage.PageCursor{}, err
-	}
-
-	return storage.PageCursor{
-		SortValue: cursor.SortValue,
-		ID:        cursor.ID,
-	}, nil
-}
-
-func encodeCursor(route string, status string, sortValue string, id string) string {
-	payload, err := json.Marshal(pageCursor{
-		Version:   cursorVersion,
-		Route:     route,
-		Status:    status,
-		SortValue: sortValue,
-		ID:        id,
-	})
-	if err != nil {
-		return ""
-	}
-	return base64.RawURLEncoding.EncodeToString(payload)
-}
-
-func pageQueryFromRequest(r *http.Request, route string) (storage.PageQuery, int, error) {
-	limit, err := parseLimit(r.URL.Query().Get("limit"))
-	if err != nil {
-		return storage.PageQuery{}, 0, err
-	}
-
-	cursor, err := parseCursor(r.URL.Query().Get("cursor"), route, "")
-	if err != nil {
-		return storage.PageQuery{}, 0, err
-	}
-
-	return storage.PageQuery{
-		Limit:  limit + 1,
-		Cursor: cursor,
-	}, limit, nil
-}
-
-func notificationListQueryFromRequest(r *http.Request, route string) (storage.NotificationListQuery, int, error) {
-	status, err := parseNotificationStatus(r.URL.Query().Get("status"))
-	if err != nil {
-		return storage.NotificationListQuery{}, 0, err
-	}
-
-	limit, err := parseLimit(r.URL.Query().Get("limit"))
-	if err != nil {
-		return storage.NotificationListQuery{}, 0, err
-	}
-
-	cursor, err := parseCursor(r.URL.Query().Get("cursor"), route, status)
-	if err != nil {
-		return storage.NotificationListQuery{}, 0, err
-	}
-
-	return storage.NotificationListQuery{
-		Limit:  limit + 1,
-		Cursor: cursor,
-		Status: status,
-	}, limit, nil
-}
-
-func effectiveJobSortValue(job storage.PublishJob) string {
-	if job.ScheduledAt != "" {
-		return job.ScheduledAt
-	}
-	return job.CreatedAt
-}
-
-func makeListResponse[T any](items []T, limit int, route string, status string, keyFunc func(T) (string, string)) listResponse[T] {
-	if items == nil {
-		items = make([]T, 0)
-	}
-
-	response := listResponse[T]{
-		Items: items,
-	}
-
-	if len(items) <= limit {
-		return response
-	}
-
-	response.HasMore = true
-	response.Items = items[:limit]
-	sortValue, id := keyFunc(response.Items[len(response.Items)-1])
-	response.NextCursor = encodeCursor(route, status, sortValue, id)
-	return response
 }
 
 // Health check
@@ -569,7 +403,7 @@ func (s *Server) handleListUserNotifications(w http.ResponseWriter, r *http.Requ
 	}
 
 	response := makeListResponse(jobs, limit, route, query.Status, func(job storage.PublishJob) (string, string) {
-		return effectiveJobSortValue(job), job.ID
+		return notificationJobCursorTime(job), job.ID
 	})
 	s.respond(w, r, response, http.StatusOK)
 }
@@ -622,6 +456,10 @@ func (s *Server) handleSendToUser(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "User not found", http.StatusNotFound)
 			return
 		}
+		if strings.Contains(err.Error(), "scheduledAt") {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		http.Error(w, "Error sending notification", http.StatusInternalServerError)
 		log.Printf("Error sending notification to user: %v", err)
 		return
@@ -663,20 +501,14 @@ func (s *Server) handleCreateTopic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.ID == "" || req.Name == "" {
-		http.Error(w, "topic id and name are required", http.StatusBadRequest)
-		return
-	}
-
-	if strings.Contains(req.ID, " ") {
-		http.Error(w, "topic id cannot contain spaces", http.StatusBadRequest)
-		return
-	}
-
 	topic, err := s.service.CreateTopic(r.Context(), req.ID, req.Name)
 	if err != nil {
 		if errors.Is(err, storage.Errors.AlreadyExists) {
 			http.Error(w, "Topic already exists", http.StatusConflict)
+			return
+		}
+		if strings.Contains(err.Error(), "topic id") {
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		http.Error(w, "Error creating topic", http.StatusInternalServerError)
@@ -814,7 +646,7 @@ func (s *Server) handleListTopicNotifications(w http.ResponseWriter, r *http.Req
 	}
 
 	response := makeListResponse(jobs, limit, route, query.Status, func(job storage.PublishJob) (string, string) {
-		return effectiveJobSortValue(job), job.ID
+		return notificationJobCursorTime(job), job.ID
 	})
 	s.respond(w, r, response, http.StatusOK)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +27,35 @@ type Server struct {
 }
 
 const immediateEnqueueTimeout = 2 * time.Second
+
+const (
+	defaultPageLimit = 50
+	maxPageLimit     = 200
+	cursorVersion    = 1
+)
+
+var validNotificationStatuses = map[string]struct{}{
+	"QUEUED":      {},
+	"SCHEDULED":   {},
+	"IN_PROGRESS": {},
+	"DISPATCHED":  {},
+	"COMPLETED":   {},
+	"FAILED":      {},
+}
+
+type listResponse[T any] struct {
+	Items      []T    `json:"items"`
+	NextCursor string `json:"next_cursor"`
+	HasMore    bool   `json:"has_more"`
+}
+
+type pageCursor struct {
+	Version   int    `json:"v"`
+	Route     string `json:"route"`
+	Status    string `json:"status,omitempty"`
+	SortValue string `json:"sort_value"`
+	ID        string `json:"id"`
+}
 
 func New(s *service.PushboyService, jobPipeline pipeline.Pipeline[model.JobItem]) *Server {
 	return &Server{service: s, jobPipeline: jobPipeline}
@@ -51,9 +82,11 @@ func (s *Server) setupRouter() chi.Router {
 
 	r.Route("/v1", func(r chi.Router) {
 		r.Get("/ping", s.handlePing)
+		r.Get("/notifications/{jobID}", s.handleGetJobStatus)
 
 		// User routes
 		r.Route("/users", func(r chi.Router) {
+			r.Get("/", s.handleListUsers)
 			r.Post("/", s.handleCreateUser)
 			r.Get("/{userID}", s.handleGetUser)
 			r.Delete("/{userID}", s.handleDeleteUser)
@@ -67,6 +100,7 @@ func (s *Server) setupRouter() chi.Router {
 			r.Post("/{userID}/subscriptions/{topicID}", s.handleSubscribeToTopic)
 			r.Delete("/{userID}/subscriptions/{topicID}", s.handleUnsubscribeFromTopic)
 			r.Get("/{userID}/subscriptions", s.handleGetUserSubscriptions)
+			r.Get("/{userID}/notifications", s.handleListUserNotifications)
 
 			// Send to user
 			r.Post("/{userID}/send", s.handleSendToUser)
@@ -79,9 +113,10 @@ func (s *Server) setupRouter() chi.Router {
 			r.Get("/{topicID}", s.handleGetTopicByID)
 			r.Delete("/{topicID}", s.handleDeleteTopic)
 			r.Get("/{topicID}/count", s.handleGetTopicSubscriberCount)
+			r.Get("/{topicID}/subscribers", s.handleListTopicSubscribers)
+			r.Get("/{topicID}/notifications", s.handleListTopicNotifications)
 
 			r.Post("/{topicID}/publish", s.handlePublishToTopic)
-			r.Get("/{topicID}/publish/{jobID}", s.handleGetJobStatus)
 		})
 
 		r.Route("/live-activity", func(r chi.Router) {
@@ -116,6 +151,141 @@ func (s *Server) enqueueImmediateJob(jobID string, jobItem model.JobItem) error 
 	return nil
 }
 
+func parseLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultPageLimit, nil
+	}
+
+	limit, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, err
+	}
+	if limit <= 0 || limit > maxPageLimit {
+		return 0, errors.New("limit out of range")
+	}
+
+	return limit, nil
+}
+
+func parseNotificationStatus(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if _, ok := validNotificationStatuses[raw]; !ok {
+		return "", errors.New("invalid status")
+	}
+	return raw, nil
+}
+
+func parseCursor(raw string, route string, status string) (storage.PageCursor, error) {
+	if raw == "" {
+		return storage.PageCursor{}, nil
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return storage.PageCursor{}, err
+	}
+
+	var cursor pageCursor
+	if err := json.Unmarshal(payload, &cursor); err != nil {
+		return storage.PageCursor{}, err
+	}
+
+	if cursor.Version != cursorVersion || cursor.Route != route || cursor.Status != status || cursor.SortValue == "" || cursor.ID == "" {
+		return storage.PageCursor{}, errors.New("invalid cursor")
+	}
+	if _, err := time.Parse(time.RFC3339, cursor.SortValue); err != nil {
+		return storage.PageCursor{}, err
+	}
+
+	return storage.PageCursor{
+		SortValue: cursor.SortValue,
+		ID:        cursor.ID,
+	}, nil
+}
+
+func encodeCursor(route string, status string, sortValue string, id string) string {
+	payload, err := json.Marshal(pageCursor{
+		Version:   cursorVersion,
+		Route:     route,
+		Status:    status,
+		SortValue: sortValue,
+		ID:        id,
+	})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func pageQueryFromRequest(r *http.Request, route string) (storage.PageQuery, int, error) {
+	limit, err := parseLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		return storage.PageQuery{}, 0, err
+	}
+
+	cursor, err := parseCursor(r.URL.Query().Get("cursor"), route, "")
+	if err != nil {
+		return storage.PageQuery{}, 0, err
+	}
+
+	return storage.PageQuery{
+		Limit:  limit + 1,
+		Cursor: cursor,
+	}, limit, nil
+}
+
+func notificationListQueryFromRequest(r *http.Request, route string) (storage.NotificationListQuery, int, error) {
+	status, err := parseNotificationStatus(r.URL.Query().Get("status"))
+	if err != nil {
+		return storage.NotificationListQuery{}, 0, err
+	}
+
+	limit, err := parseLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		return storage.NotificationListQuery{}, 0, err
+	}
+
+	cursor, err := parseCursor(r.URL.Query().Get("cursor"), route, status)
+	if err != nil {
+		return storage.NotificationListQuery{}, 0, err
+	}
+
+	return storage.NotificationListQuery{
+		Limit:  limit + 1,
+		Cursor: cursor,
+		Status: status,
+	}, limit, nil
+}
+
+func effectiveJobSortValue(job storage.PublishJob) string {
+	if job.ScheduledAt != "" {
+		return job.ScheduledAt
+	}
+	return job.CreatedAt
+}
+
+func makeListResponse[T any](items []T, limit int, route string, status string, keyFunc func(T) (string, string)) listResponse[T] {
+	if items == nil {
+		items = make([]T, 0)
+	}
+
+	response := listResponse[T]{
+		Items: items,
+	}
+
+	if len(items) <= limit {
+		return response
+	}
+
+	response.HasMore = true
+	response.Items = items[:limit]
+	sortValue, id := keyFunc(response.Items[len(response.Items)-1])
+	response.NextCursor = encodeCursor(route, status, sortValue, id)
+	return response
+}
+
 // Health check
 func (s *Server) handlePing(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("pong"))
@@ -145,6 +315,28 @@ func (s *Server) handleCreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.respond(w, r, user, http.StatusCreated)
+}
+
+func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	const route = "/v1/users"
+
+	query, limit, err := pageQueryFromRequest(r, route)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+
+	users, err := s.service.ListUsers(r.Context(), query)
+	if err != nil {
+		http.Error(w, "Error listing users", http.StatusInternalServerError)
+		log.Printf("Error listing users: %v", err)
+		return
+	}
+
+	response := makeListResponse(users, limit, route, "", func(user storage.User) (string, string) {
+		return user.CreatedAt, user.ID
+	})
+	s.respond(w, r, response, http.StatusOK)
 }
 
 func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
@@ -351,6 +543,37 @@ func (s *Server) handleGetUserSubscriptions(w http.ResponseWriter, r *http.Reque
 	s.respond(w, r, subs, http.StatusOK)
 }
 
+func (s *Server) handleListUserNotifications(w http.ResponseWriter, r *http.Request) {
+	userID := chi.URLParam(r, "userID")
+	if userID == "" {
+		http.Error(w, "userID is required", http.StatusBadRequest)
+		return
+	}
+
+	route := "/v1/users/" + userID + "/notifications"
+	query, limit, err := notificationListQueryFromRequest(r, route)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+
+	jobs, err := s.service.ListUserNotifications(r.Context(), userID, query)
+	if err != nil {
+		if errors.Is(err, storage.Errors.NotFound) {
+			http.Error(w, "User not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Error listing user notifications", http.StatusInternalServerError)
+		log.Printf("Error listing user notifications: %v", err)
+		return
+	}
+
+	response := makeListResponse(jobs, limit, route, query.Status, func(job storage.PublishJob) (string, string) {
+		return effectiveJobSortValue(job), job.ID
+	})
+	s.respond(w, r, response, http.StatusOK)
+}
+
 // Send to user handler
 
 type SendNotificationRequest struct {
@@ -532,6 +755,68 @@ func (s *Server) handleGetTopicSubscriberCount(w http.ResponseWriter, r *http.Re
 	}
 
 	s.respond(w, r, map[string]int{"count": count}, http.StatusOK)
+}
+
+func (s *Server) handleListTopicSubscribers(w http.ResponseWriter, r *http.Request) {
+	topicID := chi.URLParam(r, "topicID")
+	if topicID == "" {
+		http.Error(w, "topicID is required", http.StatusBadRequest)
+		return
+	}
+
+	route := "/v1/topics/" + topicID + "/subscribers"
+	query, limit, err := pageQueryFromRequest(r, route)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+
+	subscribers, err := s.service.ListTopicSubscribers(r.Context(), topicID, query)
+	if err != nil {
+		if errors.Is(err, storage.Errors.NotFound) {
+			http.Error(w, "Topic not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Error listing topic subscribers", http.StatusInternalServerError)
+		log.Printf("Error listing topic subscribers: %v", err)
+		return
+	}
+
+	response := makeListResponse(subscribers, limit, route, "", func(subscriber storage.TopicSubscriber) (string, string) {
+		return subscriber.SubscribedAt, subscriber.ID
+	})
+	s.respond(w, r, response, http.StatusOK)
+}
+
+func (s *Server) handleListTopicNotifications(w http.ResponseWriter, r *http.Request) {
+	topicID := chi.URLParam(r, "topicID")
+	if topicID == "" {
+		http.Error(w, "topicID is required", http.StatusBadRequest)
+		return
+	}
+
+	route := "/v1/topics/" + topicID + "/notifications"
+	query, limit, err := notificationListQueryFromRequest(r, route)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+
+	jobs, err := s.service.ListTopicNotifications(r.Context(), topicID, query)
+	if err != nil {
+		if errors.Is(err, storage.Errors.NotFound) {
+			http.Error(w, "Topic not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "Error listing topic notifications", http.StatusInternalServerError)
+		log.Printf("Error listing topic notifications: %v", err)
+		return
+	}
+
+	response := makeListResponse(jobs, limit, route, query.Status, func(job storage.PublishJob) (string, string) {
+		return effectiveJobSortValue(job), job.ID
+	})
+	s.respond(w, r, response, http.StatusOK)
 }
 
 // Publish handlers

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/mithileshchellappan/pushboy/internal/model"
 	"github.com/mithileshchellappan/pushboy/internal/service"
 	"github.com/mithileshchellappan/pushboy/internal/storage"
 )
@@ -159,14 +160,14 @@ func TestTopicNotificationsPassStatusFilter(t *testing.T) {
 			if topicID != "topic-1" {
 				t.Fatalf("unexpected topicID %q", topicID)
 			}
-			if query.Status != "COMPLETED" {
+			if query.Status != model.NotificationJobStatusCompleted {
 				t.Fatalf("expected status COMPLETED, got %q", query.Status)
 			}
 			if query.Limit != defaultPageLimit+1 {
 				t.Fatalf("expected default storage limit %d, got %d", defaultPageLimit+1, query.Limit)
 			}
 			return []storage.PublishJob{
-				{ID: "job-1", TopicID: "topic-1", Status: "COMPLETED", CreatedAt: "2026-05-01T10:00:00Z"},
+				{ID: "job-1", TopicID: "topic-1", Status: model.NotificationJobStatusCompleted, CreatedAt: "2026-05-01T10:00:00Z"},
 			}, nil
 		},
 	}
@@ -186,7 +187,7 @@ func TestCanonicalNotificationLookupAndOldRouteRemoval(t *testing.T) {
 			if jobID != "job-1" {
 				t.Fatalf("unexpected jobID %q", jobID)
 			}
-			return &storage.PublishJob{ID: "job-1", Status: "QUEUED", CreatedAt: "2026-05-01T10:00:00Z"}, nil
+			return &storage.PublishJob{ID: "job-1", Status: model.NotificationJobStatusQueued, CreatedAt: "2026-05-01T10:00:00Z"}, nil
 		},
 	})
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,206 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mithileshchellappan/pushboy/internal/service"
+	"github.com/mithileshchellappan/pushboy/internal/storage"
+)
+
+type fakeStore struct {
+	storage.Store
+
+	getUser                func(context.Context, string) (*storage.User, error)
+	getTopicByID           func(context.Context, string) (*storage.Topic, error)
+	listUsers              func(context.Context, storage.PageQuery) ([]storage.User, error)
+	listTopicSubscribers   func(context.Context, string, storage.PageQuery) ([]storage.TopicSubscriber, error)
+	listTopicNotifications func(context.Context, string, storage.NotificationListQuery) ([]storage.PublishJob, error)
+	listUserNotifications  func(context.Context, string, storage.NotificationListQuery) ([]storage.PublishJob, error)
+	getJobStatus           func(context.Context, string) (*storage.PublishJob, error)
+}
+
+func (f *fakeStore) GetUser(ctx context.Context, userID string) (*storage.User, error) {
+	if f.getUser != nil {
+		return f.getUser(ctx, userID)
+	}
+	return &storage.User{ID: userID, CreatedAt: "2026-05-01T10:00:00Z"}, nil
+}
+
+func (f *fakeStore) GetTopicByID(ctx context.Context, topicID string) (*storage.Topic, error) {
+	if f.getTopicByID != nil {
+		return f.getTopicByID(ctx, topicID)
+	}
+	return &storage.Topic{ID: topicID, Name: topicID}, nil
+}
+
+func (f *fakeStore) ListUsers(ctx context.Context, query storage.PageQuery) ([]storage.User, error) {
+	return f.listUsers(ctx, query)
+}
+
+func (f *fakeStore) ListTopicSubscribers(ctx context.Context, topicID string, query storage.PageQuery) ([]storage.TopicSubscriber, error) {
+	return f.listTopicSubscribers(ctx, topicID, query)
+}
+
+func (f *fakeStore) ListTopicNotifications(ctx context.Context, topicID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
+	return f.listTopicNotifications(ctx, topicID, query)
+}
+
+func (f *fakeStore) ListUserNotifications(ctx context.Context, userID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
+	return f.listUserNotifications(ctx, userID, query)
+}
+
+func (f *fakeStore) GetJobStatus(ctx context.Context, jobID string) (*storage.PublishJob, error) {
+	return f.getJobStatus(ctx, jobID)
+}
+
+func newTestHandler(store *fakeStore) http.Handler {
+	svc := service.NewPushBoyService(store, "")
+	return New(svc, nil).setupRouter()
+}
+
+func TestListUsersPagination(t *testing.T) {
+	store := &fakeStore{
+		listUsers: func(ctx context.Context, query storage.PageQuery) ([]storage.User, error) {
+			if query.Limit != 2 {
+				t.Fatalf("expected storage limit 2, got %d", query.Limit)
+			}
+			if query.Cursor.SortValue != "" || query.Cursor.ID != "" {
+				t.Fatalf("expected empty cursor, got %+v", query.Cursor)
+			}
+			return []storage.User{
+				{ID: "user-2", CreatedAt: "2026-05-01T11:00:00Z"},
+				{ID: "user-1", CreatedAt: "2026-05-01T10:00:00Z"},
+			}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/users?limit=1", nil)
+	rec := httptest.NewRecorder()
+	newTestHandler(store).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var response listResponse[storage.User]
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Items) != 1 || response.Items[0].ID != "user-2" {
+		t.Fatalf("unexpected items: %+v", response.Items)
+	}
+	if !response.HasMore || response.NextCursor == "" {
+		t.Fatalf("expected next cursor, got %+v", response)
+	}
+
+	cursor, err := parseCursor(response.NextCursor, "/v1/users", "")
+	if err != nil {
+		t.Fatalf("decode next cursor: %v", err)
+	}
+	if cursor.SortValue != "2026-05-01T11:00:00Z" || cursor.ID != "user-2" {
+		t.Fatalf("unexpected cursor: %+v", cursor)
+	}
+}
+
+func TestListRoutesRejectBadQueryParams(t *testing.T) {
+	handler := newTestHandler(&fakeStore{})
+
+	tests := []string{
+		"/v1/users?limit=0",
+		"/v1/users?limit=201",
+		"/v1/users?cursor=not-a-cursor",
+		"/v1/topics/topic-1/notifications?status=completed",
+		"/v1/topics/topic-1/notifications?status=UNKNOWN",
+	}
+
+	for _, target := range tests {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s: expected 400, got %d", target, rec.Code)
+		}
+	}
+}
+
+func TestListScopedRoutesReturnNotFound(t *testing.T) {
+	handler := newTestHandler(&fakeStore{
+		getUser: func(ctx context.Context, userID string) (*storage.User, error) {
+			return nil, storage.Errors.NotFound
+		},
+		getTopicByID: func(ctx context.Context, topicID string) (*storage.Topic, error) {
+			return nil, storage.Errors.NotFound
+		},
+	})
+
+	tests := []string{
+		"/v1/topics/missing/subscribers",
+		"/v1/topics/missing/notifications",
+		"/v1/users/missing/notifications",
+	}
+
+	for _, target := range tests {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s: expected 404, got %d", target, rec.Code)
+		}
+	}
+}
+
+func TestTopicNotificationsPassStatusFilter(t *testing.T) {
+	store := &fakeStore{
+		listTopicNotifications: func(ctx context.Context, topicID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
+			if topicID != "topic-1" {
+				t.Fatalf("unexpected topicID %q", topicID)
+			}
+			if query.Status != "COMPLETED" {
+				t.Fatalf("expected status COMPLETED, got %q", query.Status)
+			}
+			if query.Limit != defaultPageLimit+1 {
+				t.Fatalf("expected default storage limit %d, got %d", defaultPageLimit+1, query.Limit)
+			}
+			return []storage.PublishJob{
+				{ID: "job-1", TopicID: "topic-1", Status: "COMPLETED", CreatedAt: "2026-05-01T10:00:00Z"},
+			}, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/topics/topic-1/notifications?status=COMPLETED", nil)
+	rec := httptest.NewRecorder()
+	newTestHandler(store).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCanonicalNotificationLookupAndOldRouteRemoval(t *testing.T) {
+	handler := newTestHandler(&fakeStore{
+		getJobStatus: func(ctx context.Context, jobID string) (*storage.PublishJob, error) {
+			if jobID != "job-1" {
+				t.Fatalf("unexpected jobID %q", jobID)
+			}
+			return &storage.PublishJob{ID: "job-1", Status: "QUEUED", CreatedAt: "2026-05-01T10:00:00Z"}, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/notifications/job-1", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/topics/topic-1/publish/job-1", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected old route to be removed with 404, got %d", rec.Code)
+	}
+}

--- a/internal/service/live_activity.go
+++ b/internal/service/live_activity.go
@@ -97,7 +97,7 @@ func (s *PushboyService) RegisterLAToken(ctx context.Context, userID string, pla
 	}
 
 	if topicID != "" {
-		if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+		if _, err := s.requireTopic(ctx, topicID); err != nil {
 			return nil, nil, fmt.Errorf("topic not found: %w", err)
 		}
 		sub := &storage.LiveActivityUserTopicSubscription{
@@ -144,10 +144,10 @@ func (s *PushboyService) RegisterUserToLATopic(ctx context.Context, userID strin
 	if userID == "" || topicID == "" {
 		return nil, fmt.Errorf("userId and topicId are required")
 	}
-	if _, err := s.store.GetUser(ctx, userID); err != nil {
+	if _, err := s.requireUser(ctx, userID); err != nil {
 		return nil, fmt.Errorf("user not found: %w", err)
 	}
-	if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+	if _, err := s.requireTopic(ctx, topicID); err != nil {
 		return nil, fmt.Errorf("topic not found: %w", err)
 	}
 
@@ -234,12 +234,12 @@ func (s *PushboyService) createLAStart(ctx context.Context, req LADispatchReques
 		return nil, fmt.Errorf("provide either userId or topicId, not both")
 	}
 	if req.UserID != "" {
-		if _, err := s.store.GetUser(ctx, req.UserID); err != nil {
+		if _, err := s.requireUser(ctx, req.UserID); err != nil {
 			return nil, fmt.Errorf("user not found: %w", err)
 		}
 	}
 	if req.TopicID != "" {
-		if _, err := s.store.GetTopicByID(ctx, req.TopicID); err != nil {
+		if _, err := s.requireTopic(ctx, req.TopicID); err != nil {
 			return nil, fmt.Errorf("topic not found: %w", err)
 		}
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -74,6 +74,10 @@ func (s *PushboyService) GetUser(ctx context.Context, userID string) (*storage.U
 	return s.store.GetUser(ctx, userID)
 }
 
+func (s *PushboyService) ListUsers(ctx context.Context, query storage.PageQuery) ([]storage.User, error) {
+	return s.store.ListUsers(ctx, query)
+}
+
 func (s *PushboyService) ensureUser(ctx context.Context, userID string) (*storage.User, error) {
 	user, err := s.store.GetUser(ctx, userID)
 	if err == nil {
@@ -183,6 +187,14 @@ func (s *PushboyService) GetTopicSubscriberCount(ctx context.Context, topicID st
 	return s.store.GetTopicSubscriberCount(ctx, topicID)
 }
 
+func (s *PushboyService) ListTopicSubscribers(ctx context.Context, topicID string, query storage.PageQuery) ([]storage.TopicSubscriber, error) {
+	if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+		return nil, err
+	}
+
+	return s.store.ListTopicSubscribers(ctx, topicID, query)
+}
+
 // User-Topic subscription operations
 
 func (s *PushboyService) SubscribeUserToTopic(ctx context.Context, userID string, topicID string) (*storage.UserTopicSubscription, error) {
@@ -279,6 +291,22 @@ func (s *PushboyService) CreatePublishJob(ctx context.Context, topicID string, p
 
 func (s *PushboyService) GetJobStatus(ctx context.Context, jobID string) (*storage.PublishJob, error) {
 	return s.store.GetJobStatus(ctx, jobID)
+}
+
+func (s *PushboyService) ListTopicNotifications(ctx context.Context, topicID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
+	if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+		return nil, err
+	}
+
+	return s.store.ListTopicNotifications(ctx, topicID, query)
+}
+
+func (s *PushboyService) ListUserNotifications(ctx context.Context, userID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
+	if _, err := s.store.GetUser(ctx, userID); err != nil {
+		return nil, err
+	}
+
+	return s.store.ListUserNotifications(ctx, userID, query)
 }
 
 func (s *PushboyService) UpdateJobStatus(ctx context.Context, jobID string, status string) error {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -78,6 +78,10 @@ func (s *PushboyService) ListUsers(ctx context.Context, query storage.PageQuery)
 	return s.store.ListUsers(ctx, query)
 }
 
+func (s *PushboyService) requireUser(ctx context.Context, userID string) (*storage.User, error) {
+	return s.store.GetUser(ctx, userID)
+}
+
 func (s *PushboyService) ensureUser(ctx context.Context, userID string) (*storage.User, error) {
 	user, err := s.store.GetUser(ctx, userID)
 	if err == nil {
@@ -160,6 +164,9 @@ func (s *PushboyService) CreateTopic(ctx context.Context, ID string, name string
 	if ID == "" || name == "" {
 		return nil, fmt.Errorf("topic id and name are required")
 	}
+	if strings.Contains(ID, " ") {
+		return nil, fmt.Errorf("topic id cannot contain spaces")
+	}
 
 	topic := &storage.Topic{ID: ID, Name: name}
 
@@ -179,6 +186,10 @@ func (s *PushboyService) GetTopicByID(ctx context.Context, topicID string) (*sto
 	return s.store.GetTopicByID(ctx, topicID)
 }
 
+func (s *PushboyService) requireTopic(ctx context.Context, topicID string) (*storage.Topic, error) {
+	return s.store.GetTopicByID(ctx, topicID)
+}
+
 func (s *PushboyService) DeleteTopic(ctx context.Context, topicID string) error {
 	return s.store.DeleteTopic(ctx, topicID)
 }
@@ -188,7 +199,7 @@ func (s *PushboyService) GetTopicSubscriberCount(ctx context.Context, topicID st
 }
 
 func (s *PushboyService) ListTopicSubscribers(ctx context.Context, topicID string, query storage.PageQuery) ([]storage.TopicSubscriber, error) {
-	if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+	if _, err := s.requireTopic(ctx, topicID); err != nil {
 		return nil, err
 	}
 
@@ -199,13 +210,13 @@ func (s *PushboyService) ListTopicSubscribers(ctx context.Context, topicID strin
 
 func (s *PushboyService) SubscribeUserToTopic(ctx context.Context, userID string, topicID string) (*storage.UserTopicSubscription, error) {
 	// Verify user exists
-	_, err := s.store.GetUser(ctx, userID)
+	_, err := s.requireUser(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("user not found: %w", err)
 	}
 
 	// Verify topic exists
-	_, err = s.store.GetTopicByID(ctx, topicID)
+	_, err = s.requireTopic(ctx, topicID)
 	if err != nil {
 		return nil, fmt.Errorf("topic not found: %w", err)
 	}
@@ -234,21 +245,15 @@ func (s *PushboyService) SendToUser(ctx context.Context, userID string, payload 
 		return nil, err
 	}
 
-	var status string
-	if scheduledAt == "" {
-		status = "QUEUED"
-	} else {
-		status = "SCHEDULED"
-	}
 	job := &storage.PublishJob{
 		ID:           uuid.New().String(),
 		UserID:       userID,
 		Payload:      payload,
-		Status:       status,
+		Status:       notificationJobStatusForSchedule(scheduledAt),
 		TotalCount:   0,
 		SuccessCount: 0,
 		FailureCount: 0,
-		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339Nano),
 		ScheduledAt:  scheduledAt,
 	}
 
@@ -258,7 +263,7 @@ func (s *PushboyService) SendToUser(ctx context.Context, userID string, payload 
 // Publish job operations
 
 func (s *PushboyService) CreatePublishJob(ctx context.Context, topicID string, payload *model.NotificationPayload, scheduledAt string) (*storage.PublishJob, error) {
-	if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+	if _, err := s.requireTopic(ctx, topicID); err != nil {
 		return nil, err
 	}
 
@@ -267,22 +272,15 @@ func (s *PushboyService) CreatePublishJob(ctx context.Context, topicID string, p
 		return nil, err
 	}
 
-	var status string
-	if scheduledAt == "" {
-		status = "QUEUED"
-	} else {
-		status = "SCHEDULED"
-	}
-
 	job := &storage.PublishJob{
 		ID:           uuid.New().String(),
 		TopicID:      topicID,
 		Payload:      payload,
-		Status:       status,
+		Status:       notificationJobStatusForSchedule(scheduledAt),
 		TotalCount:   0,
 		SuccessCount: 0,
 		FailureCount: 0,
-		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339Nano),
 		ScheduledAt:  scheduledAt,
 	}
 
@@ -294,7 +292,7 @@ func (s *PushboyService) GetJobStatus(ctx context.Context, jobID string) (*stora
 }
 
 func (s *PushboyService) ListTopicNotifications(ctx context.Context, topicID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
-	if _, err := s.store.GetTopicByID(ctx, topicID); err != nil {
+	if _, err := s.requireTopic(ctx, topicID); err != nil {
 		return nil, err
 	}
 
@@ -302,13 +300,20 @@ func (s *PushboyService) ListTopicNotifications(ctx context.Context, topicID str
 }
 
 func (s *PushboyService) ListUserNotifications(ctx context.Context, userID string, query storage.NotificationListQuery) ([]storage.PublishJob, error) {
-	if _, err := s.store.GetUser(ctx, userID); err != nil {
+	if _, err := s.requireUser(ctx, userID); err != nil {
 		return nil, err
 	}
 
 	return s.store.ListUserNotifications(ctx, userID, query)
 }
 
-func (s *PushboyService) UpdateJobStatus(ctx context.Context, jobID string, status string) error {
+func (s *PushboyService) UpdateJobStatus(ctx context.Context, jobID string, status model.NotificationJobStatus) error {
 	return s.store.UpdateJobStatus(ctx, jobID, status)
+}
+
+func notificationJobStatusForSchedule(scheduledAt string) model.NotificationJobStatus {
+	if scheduledAt == "" {
+		return model.NotificationJobStatusQueued
+	}
+	return model.NotificationJobStatusScheduled
 }

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -32,7 +32,7 @@ func formatTimePtr(t sql.NullTime) string {
 	if !t.Valid {
 		return ""
 	}
-	return t.Time.UTC().Format(time.RFC3339)
+	return formatStorageTime(t.Time)
 }
 
 func scanLAToken(scanner interface{ Scan(dest ...any) error }, token *LiveActivityToken) error {
@@ -59,8 +59,8 @@ func scanLAToken(scanner interface{ Scan(dest ...any) error }, token *LiveActivi
 
 	token.Platform = model.Platform(platform)
 	token.TokenType = model.LiveActivityTokenType(tokenType)
-	token.CreatedAt = createdAt.UTC().Format(time.RFC3339)
-	token.LastSeenAt = lastSeenAt.UTC().Format(time.RFC3339)
+	token.CreatedAt = formatStorageTime(createdAt)
+	token.LastSeenAt = formatStorageTime(lastSeenAt)
 	token.ExpiresAt = formatTimePtr(expiresAt)
 	token.InvalidatedAt = formatTimePtr(invalidatedAt)
 	return nil
@@ -109,8 +109,8 @@ func scanLAJob(scanner interface{ Scan(dest ...any) error }, job *LiveActivityJo
 	job.Status = model.LiveActivityJobStatus(status)
 	job.LatestPayload = latestPayload
 	job.Options = options
-	job.CreatedAt = createdAt.UTC().Format(time.RFC3339)
-	job.UpdatedAt = updatedAt.UTC().Format(time.RFC3339)
+	job.CreatedAt = formatStorageTime(createdAt)
+	job.UpdatedAt = formatStorageTime(updatedAt)
 	job.ExpiresAt = formatTimePtr(expiresAt)
 	job.ClosedAt = formatTimePtr(closedAt)
 	return nil
@@ -131,7 +131,7 @@ func laConstraint(err error) string {
 }
 
 func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *LiveActivityToken) (*LiveActivityToken, error) {
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := formatStorageTime(time.Now().UTC())
 	if token.ID == "" {
 		token.ID = token.Token
 	}
@@ -211,7 +211,7 @@ func (s *PostgresStore) SubscribeUserToLATopic(ctx context.Context, sub *LiveAct
 	if err := row.Scan(&stored.ID, &stored.UserID, &stored.TopicID, &createdAt); err != nil {
 		return nil, fmt.Errorf("error subscribing user to LA topic: %w", err)
 	}
-	stored.CreatedAt = createdAt.UTC().Format(time.RFC3339)
+	stored.CreatedAt = formatStorageTime(createdAt)
 	return &stored, nil
 }
 
@@ -693,7 +693,7 @@ func (s *PostgresStore) completeEmptyLADispatch(ctx context.Context, dispatchID 
 			return fmt.Errorf("error failing empty LA start job: %w", err)
 		}
 	case string(model.LiveActivityActionEnd):
-		if err := s.CloseLAJobIfActive(ctx, jobID, time.Now().UTC().Format(time.RFC3339)); err != nil && !errors.Is(err, Errors.NotFound) {
+		if err := s.CloseLAJobIfActive(ctx, jobID, formatStorageTime(time.Now().UTC())); err != nil && !errors.Is(err, Errors.NotFound) {
 			return fmt.Errorf("error closing empty LA end job: %w", err)
 		}
 	}

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -28,20 +28,9 @@ func nullableJSONRawMessage(value json.RawMessage) any {
 	return []byte(trimmed)
 }
 
-func formatTimePtr(t sql.NullTime) string {
-	if !t.Valid {
-		return ""
-	}
-	return formatStorageTime(t.Time)
-}
-
 func scanLAToken(scanner interface{ Scan(dest ...any) error }, token *LiveActivityToken) error {
 	var platform string
 	var tokenType string
-	var createdAt time.Time
-	var lastSeenAt time.Time
-	var expiresAt sql.NullTime
-	var invalidatedAt sql.NullTime
 
 	if err := scanner.Scan(
 		&token.ID,
@@ -49,20 +38,16 @@ func scanLAToken(scanner interface{ Scan(dest ...any) error }, token *LiveActivi
 		&platform,
 		&tokenType,
 		&token.Token,
-		&createdAt,
-		&lastSeenAt,
-		&expiresAt,
-		&invalidatedAt,
+		scanStorageTime(&token.CreatedAt),
+		scanStorageTime(&token.LastSeenAt),
+		scanStorageTime(&token.ExpiresAt),
+		scanStorageTime(&token.InvalidatedAt),
 	); err != nil {
 		return err
 	}
 
 	token.Platform = model.Platform(platform)
 	token.TokenType = model.LiveActivityTokenType(tokenType)
-	token.CreatedAt = formatStorageTime(createdAt)
-	token.LastSeenAt = formatStorageTime(lastSeenAt)
-	token.ExpiresAt = formatTimePtr(expiresAt)
-	token.InvalidatedAt = formatTimePtr(invalidatedAt)
 	return nil
 }
 
@@ -84,10 +69,6 @@ func scanLAJob(scanner interface{ Scan(dest ...any) error }, job *LiveActivityJo
 	var status string
 	var latestPayload []byte
 	var options []byte
-	var createdAt time.Time
-	var updatedAt time.Time
-	var expiresAt sql.NullTime
-	var closedAt sql.NullTime
 
 	if err := scanner.Scan(
 		&job.ID,
@@ -98,10 +79,10 @@ func scanLAJob(scanner interface{ Scan(dest ...any) error }, job *LiveActivityJo
 		&status,
 		&latestPayload,
 		&options,
-		&createdAt,
-		&updatedAt,
-		&expiresAt,
-		&closedAt,
+		scanStorageTime(&job.CreatedAt),
+		scanStorageTime(&job.UpdatedAt),
+		scanStorageTime(&job.ExpiresAt),
+		scanStorageTime(&job.ClosedAt),
 	); err != nil {
 		return err
 	}
@@ -109,10 +90,6 @@ func scanLAJob(scanner interface{ Scan(dest ...any) error }, job *LiveActivityJo
 	job.Status = model.LiveActivityJobStatus(status)
 	job.LatestPayload = latestPayload
 	job.Options = options
-	job.CreatedAt = formatStorageTime(createdAt)
-	job.UpdatedAt = formatStorageTime(updatedAt)
-	job.ExpiresAt = formatTimePtr(expiresAt)
-	job.ClosedAt = formatTimePtr(closedAt)
 	return nil
 }
 
@@ -207,11 +184,9 @@ func (s *PostgresStore) SubscribeUserToLATopic(ctx context.Context, sub *LiveAct
 	)
 
 	var stored LiveActivityUserTopicSubscription
-	var createdAt time.Time
-	if err := row.Scan(&stored.ID, &stored.UserID, &stored.TopicID, &createdAt); err != nil {
+	if err := row.Scan(&stored.ID, &stored.UserID, &stored.TopicID, scanStorageTime(&stored.CreatedAt)); err != nil {
 		return nil, fmt.Errorf("error subscribing user to LA topic: %w", err)
 	}
-	stored.CreatedAt = formatStorageTime(createdAt)
 	return &stored, nil
 }
 

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -708,9 +708,9 @@ func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelt
 		dispatchID := outcome.Receipt.JobID
 		delta := deltas[dispatchID]
 		switch outcome.Receipt.Status {
-		case string(model.Success):
+		case model.DeliveryStatusSuccess:
 			delta.success++
-		case string(model.Failed):
+		case model.DeliveryStatusFailed:
 			delta.failure++
 			if isLAInvalidToken(outcome.Receipt.StatusReason) {
 				invalidTokenIDs[outcome.Receipt.TokenID] = struct{}{}

--- a/internal/storage/outcome.go
+++ b/internal/storage/outcome.go
@@ -17,9 +17,9 @@ func summarizePushReceipts(receipts []model.DeliveryReceipt) (map[string]*pushOu
 		}
 
 		switch receipt.Status {
-		case string(model.Success):
+		case model.DeliveryStatusSuccess:
 			deltas[receipt.JobID].success++
-		case string(model.Failed):
+		case model.DeliveryStatusFailed:
 			deltas[receipt.JobID].failure++
 			failureReceipts = append(failureReceipts, receipt)
 		}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -22,7 +22,7 @@ type PostgresStore struct {
 
 var _ Store = (*PostgresStore)(nil)
 
-type sqlScanner interface {
+type rowScanner interface {
 	Scan(dest ...any) error
 }
 
@@ -72,37 +72,10 @@ func NewPostgresStore(databaseURL string) (*PostgresStore, error) {
 	return store, nil
 }
 
-func formatPostgresTime(t time.Time) string {
-	return t.UTC().Format(time.RFC3339Nano)
-}
-
-func parseRequiredPostgresTime(value string) (time.Time, error) {
-	if value == "" {
-		return time.Now().UTC(), nil
-	}
-
-	t, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return t.UTC(), nil
-}
-
-func parseOptionalPostgresTime(value string) (any, error) {
-	if value == "" {
-		return nil, nil
-	}
-
-	t, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return nil, err
-	}
-	return t.UTC(), nil
-}
-
-func scanPublishJob(scanner sqlScanner) (*PublishJob, error) {
+func scanPublishJob(scanner rowScanner) (*PublishJob, error) {
 	var job PublishJob
 	var payloadJSON []byte
+	var status string
 	var createdAt time.Time
 	var completedAt sql.NullTime
 	var scheduledAt sql.NullTime
@@ -112,7 +85,7 @@ func scanPublishJob(scanner sqlScanner) (*PublishJob, error) {
 		&job.TopicID,
 		&job.UserID,
 		&payloadJSON,
-		&job.Status,
+		&status,
 		&job.TotalCount,
 		&job.SuccessCount,
 		&job.FailureCount,
@@ -124,12 +97,13 @@ func scanPublishJob(scanner sqlScanner) (*PublishJob, error) {
 		return nil, err
 	}
 
-	job.CreatedAt = formatPostgresTime(createdAt)
+	job.Status = model.NotificationJobStatus(status)
+	job.CreatedAt = formatStorageTime(createdAt)
 	if completedAt.Valid {
-		job.CompletedAt = formatPostgresTime(completedAt.Time)
+		job.CompletedAt = formatStorageTime(completedAt.Time)
 	}
 	if scheduledAt.Valid {
-		job.ScheduledAt = formatPostgresTime(scheduledAt.Time)
+		job.ScheduledAt = formatStorageTime(scheduledAt.Time)
 	}
 
 	if len(payloadJSON) > 0 {
@@ -147,7 +121,7 @@ func scanPublishJob(scanner sqlScanner) (*PublishJob, error) {
 
 func (s *PostgresStore) CreateUser(ctx context.Context, user *User) (*User, error) {
 	createdAt := time.Now().UTC()
-	user.CreatedAt = formatPostgresTime(createdAt)
+	user.CreatedAt = formatStorageTime(createdAt)
 
 	query := `INSERT INTO users(id, created_at) VALUES($1, $2)`
 	_, err := s.db.ExecContext(ctx, query, user.ID, createdAt)
@@ -174,7 +148,7 @@ func (s *PostgresStore) GetUser(ctx context.Context, userID string) (*User, erro
 	if err != nil {
 		return nil, fmt.Errorf("error getting user: %w", err)
 	}
-	user.CreatedAt = formatPostgresTime(createdAt)
+	user.CreatedAt = formatStorageTime(createdAt)
 
 	return &user, nil
 }
@@ -204,7 +178,7 @@ func (s *PostgresStore) ListUsers(ctx context.Context, query PageQuery) ([]User,
 		if err := rows.Scan(&user.ID, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning user: %w", err)
 		}
-		user.CreatedAt = formatPostgresTime(createdAt)
+		user.CreatedAt = formatStorageTime(createdAt)
 		users = append(users, user)
 	}
 
@@ -230,7 +204,7 @@ func (s *PostgresStore) DeleteUser(ctx context.Context, userID string) error {
 
 func (s *PostgresStore) CreateToken(ctx context.Context, token *Token) (*Token, error) {
 	createdAt := time.Now().UTC()
-	token.CreatedAt = formatPostgresTime(createdAt)
+	token.CreatedAt = formatStorageTime(createdAt)
 
 	query := `INSERT INTO tokens(id, user_id, platform, token, created_at) VALUES($1, $2, $3, $4, $5)`
 	_, err := s.db.ExecContext(ctx, query, token.ID, token.UserID, token.Platform, token.Token, createdAt)
@@ -259,7 +233,7 @@ func (s *PostgresStore) GetTokensByUserID(ctx context.Context, userID string) ([
 		if err := rows.Scan(&token.ID, &token.UserID, &token.Platform, &token.Token, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning token: %w", err)
 		}
-		token.CreatedAt = formatPostgresTime(createdAt)
+		token.CreatedAt = formatStorageTime(createdAt)
 		tokens = append(tokens, token)
 	}
 
@@ -491,7 +465,7 @@ func (s *PostgresStore) DeleteTopic(ctx context.Context, topicID string) error {
 func (s *PostgresStore) SubscribeUserToTopic(ctx context.Context, sub *UserTopicSubscription) (*UserTopicSubscription, error) {
 	sub.ID = fmt.Sprintf("sub:%s:%s", sub.UserID, sub.TopicID)
 	createdAt := time.Now().UTC()
-	sub.CreatedAt = formatPostgresTime(createdAt)
+	sub.CreatedAt = formatStorageTime(createdAt)
 
 	query := `INSERT INTO user_topic_subscriptions(id, user_id, topic_id, created_at) VALUES($1, $2, $3, $4)`
 	_, err := s.db.ExecContext(ctx, query, sub.ID, sub.UserID, sub.TopicID, createdAt)
@@ -535,7 +509,7 @@ func (s *PostgresStore) GetUserSubscriptions(ctx context.Context, userID string)
 		if err := rows.Scan(&sub.ID, &sub.UserID, &sub.TopicID, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning subscription: %w", err)
 		}
-		sub.CreatedAt = formatPostgresTime(createdAt)
+		sub.CreatedAt = formatStorageTime(createdAt)
 		subs = append(subs, sub)
 	}
 
@@ -559,7 +533,7 @@ func (s *PostgresStore) GetTopicSubscribers(ctx context.Context, topicID string)
 		if err := rows.Scan(&user.ID, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning user: %w", err)
 		}
-		user.CreatedAt = formatPostgresTime(createdAt)
+		user.CreatedAt = formatStorageTime(createdAt)
 		users = append(users, user)
 	}
 
@@ -597,8 +571,8 @@ func (s *PostgresStore) ListTopicSubscribers(ctx context.Context, topicID string
 		if err := rows.Scan(&subscriber.ID, &createdAt, &subscribedAt); err != nil {
 			return nil, fmt.Errorf("error scanning topic subscriber: %w", err)
 		}
-		subscriber.CreatedAt = formatPostgresTime(createdAt)
-		subscriber.SubscribedAt = formatPostgresTime(subscribedAt)
+		subscriber.CreatedAt = formatStorageTime(createdAt)
+		subscriber.SubscribedAt = formatStorageTime(subscribedAt)
 		subscribers = append(subscribers, subscriber)
 	}
 
@@ -628,21 +602,21 @@ func (s *PostgresStore) CreatePublishJob(ctx context.Context, job *PublishJob) (
 	if job.ScheduledAt == "" {
 		scheduledAt = nil
 	} else {
-		scheduledAt, err = parseOptionalPostgresTime(job.ScheduledAt)
+		scheduledAt, err = parseOptionalStorageTime(job.ScheduledAt)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing scheduled_at: %w", err)
 		}
 	}
 
-	createdAt, err := parseRequiredPostgresTime(job.CreatedAt)
+	createdAt, err := parseRequiredStorageTime(job.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing created_at: %w", err)
 	}
-	job.CreatedAt = formatPostgresTime(createdAt)
+	job.CreatedAt = formatStorageTime(createdAt)
 
 	query := `INSERT INTO publish_jobs(id, topic_id, payload, status, total_count, success_count, failure_count, created_at, scheduled_at) 
 		VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)`
-	_, err = s.db.ExecContext(ctx, query, job.ID, job.TopicID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, createdAt, scheduledAt)
+	_, err = s.db.ExecContext(ctx, query, job.ID, job.TopicID, payloadJSON, string(job.Status), job.TotalCount, job.SuccessCount, job.FailureCount, createdAt, scheduledAt)
 	if err != nil {
 		return nil, fmt.Errorf("error creating publish job: %w", err)
 	}
@@ -671,20 +645,20 @@ func (s *PostgresStore) CreateUserPublishJob(ctx context.Context, job *PublishJo
 	if job.ScheduledAt == "" {
 		scheduledAt = nil
 	} else {
-		scheduledAt, err = parseOptionalPostgresTime(job.ScheduledAt)
+		scheduledAt, err = parseOptionalStorageTime(job.ScheduledAt)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing scheduled_at: %w", err)
 		}
 	}
 
-	createdAt, err := parseRequiredPostgresTime(job.CreatedAt)
+	createdAt, err := parseRequiredStorageTime(job.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing created_at: %w", err)
 	}
-	job.CreatedAt = formatPostgresTime(createdAt)
+	job.CreatedAt = formatStorageTime(createdAt)
 
 	query := `INSERT INTO publish_jobs(id, user_id, payload, status, total_count, success_count, failure_count, created_at, scheduled_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)`
-	_, err = s.db.ExecContext(ctx, query, job.ID, job.UserID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, createdAt, scheduledAt)
+	_, err = s.db.ExecContext(ctx, query, job.ID, job.UserID, payloadJSON, string(job.Status), job.TotalCount, job.SuccessCount, job.FailureCount, createdAt, scheduledAt)
 	if err != nil {
 		return nil, fmt.Errorf("error creating user publish job: %w", err)
 	}
@@ -712,14 +686,14 @@ func (s *PostgresStore) FetchPendingJobs(ctx context.Context, limit int) ([]Publ
 	return jobs, rows.Err()
 }
 
-func (s *PostgresStore) UpdateJobStatus(ctx context.Context, jobID string, status string) error {
+func (s *PostgresStore) UpdateJobStatus(ctx context.Context, jobID string, status model.NotificationJobStatus) error {
 	var query string
-	if status == "COMPLETED" {
+	if status == model.NotificationJobStatusCompleted {
 		query = `UPDATE publish_jobs SET status = $1, completed_at = NOW() WHERE id = $2`
 	} else {
 		query = `UPDATE publish_jobs SET status = $1 WHERE id = $2`
 	}
-	_, err := s.db.ExecContext(ctx, query, status, jobID)
+	_, err := s.db.ExecContext(ctx, query, string(status), jobID)
 	return err
 }
 
@@ -804,7 +778,7 @@ func (s *PostgresStore) ListTopicNotifications(ctx context.Context, topicID stri
 		ORDER BY COALESCE(pj.scheduled_at, pj.created_at) DESC, pj.id DESC
 		LIMIT $5`,
 		topicID,
-		query.Status,
+		string(query.Status),
 		query.Cursor.SortValue,
 		query.Cursor.ID,
 		query.Limit,
@@ -889,7 +863,7 @@ func (s *PostgresStore) ListUserNotifications(ctx context.Context, userID string
 		ORDER BY effective_at DESC, id DESC
 		LIMIT $5`,
 		userID,
-		query.Status,
+		string(query.Status),
 		query.Cursor.SortValue,
 		query.Cursor.ID,
 		query.Limit,
@@ -969,7 +943,7 @@ func (s *PostgresStore) bulkInsertReceiptsTx(ctx context.Context, tx *sql.Tx, re
 	}
 
 	for _, r := range receipts {
-		dispatchedAt, err := parseRequiredPostgresTime(r.DispatchedAt)
+		dispatchedAt, err := parseRequiredStorageTime(r.DispatchedAt)
 		if err != nil {
 			_ = stmt.Close()
 			return fmt.Errorf("error parsing dispatched_at for job %s token %s: %w", r.JobID, r.TokenID, err)
@@ -1017,7 +991,7 @@ func (s *PostgresStore) CompleteJobIfDone(ctx context.Context, jobID string) err
 // Delivery receipt operations
 
 func (s *PostgresStore) RecordDeliveryReceipt(ctx context.Context, receipt *model.DeliveryReceipt) error {
-	dispatchedAt, err := parseRequiredPostgresTime(receipt.DispatchedAt)
+	dispatchedAt, err := parseRequiredStorageTime(receipt.DispatchedAt)
 	if err != nil {
 		return fmt.Errorf("error parsing dispatched_at: %w", err)
 	}

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -20,6 +20,12 @@ type PostgresStore struct {
 	db *sql.DB
 }
 
+var _ Store = (*PostgresStore)(nil)
+
+type sqlScanner interface {
+	Scan(dest ...any) error
+}
+
 func NewPostgresStore(databaseURL string) (*PostgresStore, error) {
 	db, err := sql.Open("postgres", databaseURL)
 	if err != nil {
@@ -66,13 +72,85 @@ func NewPostgresStore(databaseURL string) (*PostgresStore, error) {
 	return store, nil
 }
 
+func formatPostgresTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func parseRequiredPostgresTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Now().UTC(), nil
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t.UTC(), nil
+}
+
+func parseOptionalPostgresTime(value string) (any, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil, err
+	}
+	return t.UTC(), nil
+}
+
+func scanPublishJob(scanner sqlScanner) (*PublishJob, error) {
+	var job PublishJob
+	var payloadJSON []byte
+	var createdAt time.Time
+	var completedAt sql.NullTime
+	var scheduledAt sql.NullTime
+
+	err := scanner.Scan(
+		&job.ID,
+		&job.TopicID,
+		&job.UserID,
+		&payloadJSON,
+		&job.Status,
+		&job.TotalCount,
+		&job.SuccessCount,
+		&job.FailureCount,
+		&createdAt,
+		&completedAt,
+		&scheduledAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	job.CreatedAt = formatPostgresTime(createdAt)
+	if completedAt.Valid {
+		job.CompletedAt = formatPostgresTime(completedAt.Time)
+	}
+	if scheduledAt.Valid {
+		job.ScheduledAt = formatPostgresTime(scheduledAt.Time)
+	}
+
+	if len(payloadJSON) > 0 {
+		var payload model.NotificationPayload
+		if err := json.Unmarshal(payloadJSON, &payload); err != nil {
+			return nil, fmt.Errorf("error deserializing payload: %w", err)
+		}
+		job.Payload = &payload
+	}
+
+	return &job, nil
+}
+
 // User operations
 
 func (s *PostgresStore) CreateUser(ctx context.Context, user *User) (*User, error) {
-	user.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	createdAt := time.Now().UTC()
+	user.CreatedAt = formatPostgresTime(createdAt)
 
 	query := `INSERT INTO users(id, created_at) VALUES($1, $2)`
-	_, err := s.db.ExecContext(ctx, query, user.ID, user.CreatedAt)
+	_, err := s.db.ExecContext(ctx, query, user.ID, createdAt)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {
 			return nil, Errors.AlreadyExists
@@ -88,15 +166,49 @@ func (s *PostgresStore) GetUser(ctx context.Context, userID string) (*User, erro
 	row := s.db.QueryRowContext(ctx, query, userID)
 
 	var user User
-	err := row.Scan(&user.ID, &user.CreatedAt)
+	var createdAt time.Time
+	err := row.Scan(&user.ID, &createdAt)
 	if err == sql.ErrNoRows {
 		return nil, Errors.NotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error getting user: %w", err)
 	}
+	user.CreatedAt = formatPostgresTime(createdAt)
 
 	return &user, nil
+}
+
+func (s *PostgresStore) ListUsers(ctx context.Context, query PageQuery) ([]User, error) {
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT id, created_at
+		FROM users
+		WHERE NULLIF($1, '') IS NULL
+			OR (created_at, id) < (NULLIF($1, '')::timestamptz, $2)
+		ORDER BY created_at DESC, id DESC
+		LIMIT $3`,
+		query.Cursor.SortValue,
+		query.Cursor.ID,
+		query.Limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error listing users: %w", err)
+	}
+	defer rows.Close()
+
+	var users []User
+	for rows.Next() {
+		var user User
+		var createdAt time.Time
+		if err := rows.Scan(&user.ID, &createdAt); err != nil {
+			return nil, fmt.Errorf("error scanning user: %w", err)
+		}
+		user.CreatedAt = formatPostgresTime(createdAt)
+		users = append(users, user)
+	}
+
+	return users, rows.Err()
 }
 
 func (s *PostgresStore) DeleteUser(ctx context.Context, userID string) error {
@@ -117,10 +229,11 @@ func (s *PostgresStore) DeleteUser(ctx context.Context, userID string) error {
 // Token operations
 
 func (s *PostgresStore) CreateToken(ctx context.Context, token *Token) (*Token, error) {
-	token.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	createdAt := time.Now().UTC()
+	token.CreatedAt = formatPostgresTime(createdAt)
 
 	query := `INSERT INTO tokens(id, user_id, platform, token, created_at) VALUES($1, $2, $3, $4, $5)`
-	_, err := s.db.ExecContext(ctx, query, token.ID, token.UserID, token.Platform, token.Token, token.CreatedAt)
+	_, err := s.db.ExecContext(ctx, query, token.ID, token.UserID, token.Platform, token.Token, createdAt)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {
 			return nil, Errors.AlreadyExists
@@ -142,9 +255,11 @@ func (s *PostgresStore) GetTokensByUserID(ctx context.Context, userID string) ([
 	var tokens []Token
 	for rows.Next() {
 		var token Token
-		if err := rows.Scan(&token.ID, &token.UserID, &token.Platform, &token.Token, &token.CreatedAt); err != nil {
+		var createdAt time.Time
+		if err := rows.Scan(&token.ID, &token.UserID, &token.Platform, &token.Token, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning token: %w", err)
 		}
+		token.CreatedAt = formatPostgresTime(createdAt)
 		tokens = append(tokens, token)
 	}
 
@@ -375,10 +490,11 @@ func (s *PostgresStore) DeleteTopic(ctx context.Context, topicID string) error {
 
 func (s *PostgresStore) SubscribeUserToTopic(ctx context.Context, sub *UserTopicSubscription) (*UserTopicSubscription, error) {
 	sub.ID = fmt.Sprintf("sub:%s:%s", sub.UserID, sub.TopicID)
-	sub.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	createdAt := time.Now().UTC()
+	sub.CreatedAt = formatPostgresTime(createdAt)
 
 	query := `INSERT INTO user_topic_subscriptions(id, user_id, topic_id, created_at) VALUES($1, $2, $3, $4)`
-	_, err := s.db.ExecContext(ctx, query, sub.ID, sub.UserID, sub.TopicID, sub.CreatedAt)
+	_, err := s.db.ExecContext(ctx, query, sub.ID, sub.UserID, sub.TopicID, createdAt)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {
 			return nil, Errors.AlreadyExists
@@ -415,9 +531,11 @@ func (s *PostgresStore) GetUserSubscriptions(ctx context.Context, userID string)
 	var subs []UserTopicSubscription
 	for rows.Next() {
 		var sub UserTopicSubscription
-		if err := rows.Scan(&sub.ID, &sub.UserID, &sub.TopicID, &sub.CreatedAt); err != nil {
+		var createdAt time.Time
+		if err := rows.Scan(&sub.ID, &sub.UserID, &sub.TopicID, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning subscription: %w", err)
 		}
+		sub.CreatedAt = formatPostgresTime(createdAt)
 		subs = append(subs, sub)
 	}
 
@@ -437,13 +555,54 @@ func (s *PostgresStore) GetTopicSubscribers(ctx context.Context, topicID string)
 	var users []User
 	for rows.Next() {
 		var user User
-		if err := rows.Scan(&user.ID, &user.CreatedAt); err != nil {
+		var createdAt time.Time
+		if err := rows.Scan(&user.ID, &createdAt); err != nil {
 			return nil, fmt.Errorf("error scanning user: %w", err)
 		}
+		user.CreatedAt = formatPostgresTime(createdAt)
 		users = append(users, user)
 	}
 
 	return users, rows.Err()
+}
+
+func (s *PostgresStore) ListTopicSubscribers(ctx context.Context, topicID string, query PageQuery) ([]TopicSubscriber, error) {
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT u.id, u.created_at, sub.created_at
+		FROM user_topic_subscriptions sub
+		INNER JOIN users u ON u.id = sub.user_id
+		WHERE sub.topic_id = $1
+			AND (
+				NULLIF($2, '') IS NULL
+				OR (sub.created_at, sub.user_id) < (NULLIF($2, '')::timestamptz, $3)
+			)
+		ORDER BY sub.created_at DESC, sub.user_id DESC
+		LIMIT $4`,
+		topicID,
+		query.Cursor.SortValue,
+		query.Cursor.ID,
+		query.Limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error listing topic subscribers: %w", err)
+	}
+	defer rows.Close()
+
+	var subscribers []TopicSubscriber
+	for rows.Next() {
+		var subscriber TopicSubscriber
+		var createdAt time.Time
+		var subscribedAt time.Time
+		if err := rows.Scan(&subscriber.ID, &createdAt, &subscribedAt); err != nil {
+			return nil, fmt.Errorf("error scanning topic subscriber: %w", err)
+		}
+		subscriber.CreatedAt = formatPostgresTime(createdAt)
+		subscriber.SubscribedAt = formatPostgresTime(subscribedAt)
+		subscribers = append(subscribers, subscriber)
+	}
+
+	return subscribers, rows.Err()
 }
 
 func (s *PostgresStore) GetTopicSubscriberCount(ctx context.Context, topicID string) (int, error) {
@@ -469,12 +628,21 @@ func (s *PostgresStore) CreatePublishJob(ctx context.Context, job *PublishJob) (
 	if job.ScheduledAt == "" {
 		scheduledAt = nil
 	} else {
-		scheduledAt = job.ScheduledAt
+		scheduledAt, err = parseOptionalPostgresTime(job.ScheduledAt)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing scheduled_at: %w", err)
+		}
 	}
+
+	createdAt, err := parseRequiredPostgresTime(job.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing created_at: %w", err)
+	}
+	job.CreatedAt = formatPostgresTime(createdAt)
 
 	query := `INSERT INTO publish_jobs(id, topic_id, payload, status, total_count, success_count, failure_count, created_at, scheduled_at) 
 		VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)`
-	_, err = s.db.ExecContext(ctx, query, job.ID, job.TopicID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, job.CreatedAt, scheduledAt)
+	_, err = s.db.ExecContext(ctx, query, job.ID, job.TopicID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, createdAt, scheduledAt)
 	if err != nil {
 		return nil, fmt.Errorf("error creating publish job: %w", err)
 	}
@@ -503,11 +671,20 @@ func (s *PostgresStore) CreateUserPublishJob(ctx context.Context, job *PublishJo
 	if job.ScheduledAt == "" {
 		scheduledAt = nil
 	} else {
-		scheduledAt = job.ScheduledAt
+		scheduledAt, err = parseOptionalPostgresTime(job.ScheduledAt)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing scheduled_at: %w", err)
+		}
 	}
 
+	createdAt, err := parseRequiredPostgresTime(job.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing created_at: %w", err)
+	}
+	job.CreatedAt = formatPostgresTime(createdAt)
+
 	query := `INSERT INTO publish_jobs(id, user_id, payload, status, total_count, success_count, failure_count, created_at, scheduled_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9)`
-	_, err = s.db.ExecContext(ctx, query, job.ID, job.UserID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, job.CreatedAt, scheduledAt)
+	_, err = s.db.ExecContext(ctx, query, job.ID, job.UserID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, createdAt, scheduledAt)
 	if err != nil {
 		return nil, fmt.Errorf("error creating user publish job: %w", err)
 	}
@@ -515,7 +692,7 @@ func (s *PostgresStore) CreateUserPublishJob(ctx context.Context, job *PublishJo
 }
 
 func (s *PostgresStore) FetchPendingJobs(ctx context.Context, limit int) ([]PublishJob, error) {
-	query := `SELECT id, COALESCE(topic_id, ''), COALESCE(user_id, ''), payload, status, total_count, success_count, failure_count, created_at, completed_at 
+	query := `SELECT id, COALESCE(topic_id, ''), COALESCE(user_id, ''), payload, status, total_count, success_count, failure_count, created_at, completed_at, scheduled_at
 		FROM publish_jobs WHERE status = 'PENDING' LIMIT $1`
 	rows, err := s.db.QueryContext(ctx, query, limit)
 	if err != nil {
@@ -525,24 +702,11 @@ func (s *PostgresStore) FetchPendingJobs(ctx context.Context, limit int) ([]Publ
 
 	var jobs []PublishJob
 	for rows.Next() {
-		var job PublishJob
-		var payloadJSON []byte
-		var completedAt sql.NullTime
-		if err := rows.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &job.Status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &completedAt); err != nil {
+		job, err := scanPublishJob(rows)
+		if err != nil {
 			return nil, fmt.Errorf("error scanning job: %w", err)
 		}
-		if completedAt.Valid {
-			job.CompletedAt = completedAt.Time.UTC().Format(time.RFC3339)
-		}
-		// Deserialize payload from JSON
-		if len(payloadJSON) > 0 {
-			var payload model.NotificationPayload
-			if err := json.Unmarshal(payloadJSON, &payload); err != nil {
-				return nil, fmt.Errorf("error deserializing payload: %w", err)
-			}
-			job.Payload = &payload
-		}
-		jobs = append(jobs, job)
+		jobs = append(jobs, *job)
 	}
 
 	return jobs, rows.Err()
@@ -597,16 +761,14 @@ func (s *PostgresStore) GetJobStatus(ctx context.Context, jobID string) (*Publis
 			pj.success_count,
 			pj.failure_count,
 			pj.created_at,
-			pj.completed_at
+			pj.completed_at,
+			pj.scheduled_at
 		FROM publish_jobs pj
 		WHERE pj.id = $1`
 
 	row := s.db.QueryRowContext(ctx, query, jobID)
 
-	var job PublishJob
-	var payloadJSON []byte
-	var completedAt sql.NullTime
-	err := row.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &job.Status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &completedAt)
+	job, err := scanPublishJob(row)
 	if err == sql.ErrNoRows {
 		return nil, Errors.NotFound
 	}
@@ -614,20 +776,139 @@ func (s *PostgresStore) GetJobStatus(ctx context.Context, jobID string) (*Publis
 		return nil, fmt.Errorf("error getting job status: %w", err)
 	}
 
-	if completedAt.Valid {
-		job.CompletedAt = completedAt.Time.UTC().Format(time.RFC3339)
-	}
+	return job, nil
+}
 
-	// Deserialize payload from JSON
-	if len(payloadJSON) > 0 {
-		var payload model.NotificationPayload
-		if err := json.Unmarshal(payloadJSON, &payload); err != nil {
-			return nil, fmt.Errorf("error deserializing payload: %w", err)
+func (s *PostgresStore) ListTopicNotifications(ctx context.Context, topicID string, query NotificationListQuery) ([]PublishJob, error) {
+	rows, err := s.db.QueryContext(
+		ctx,
+		`SELECT
+			pj.id,
+			COALESCE(pj.topic_id, ''),
+			COALESCE(pj.user_id, ''),
+			pj.payload,
+			pj.status,
+			pj.total_count,
+			pj.success_count,
+			pj.failure_count,
+			pj.created_at,
+			pj.completed_at,
+			pj.scheduled_at
+		FROM publish_jobs pj
+		WHERE pj.topic_id = $1
+			AND ($2 = '' OR pj.status = $2)
+			AND (
+				NULLIF($3, '') IS NULL
+				OR (COALESCE(pj.scheduled_at, pj.created_at), pj.id) < (NULLIF($3, '')::timestamptz, $4)
+			)
+		ORDER BY COALESCE(pj.scheduled_at, pj.created_at) DESC, pj.id DESC
+		LIMIT $5`,
+		topicID,
+		query.Status,
+		query.Cursor.SortValue,
+		query.Cursor.ID,
+		query.Limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error listing topic notifications: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []PublishJob
+	for rows.Next() {
+		job, err := scanPublishJob(rows)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning topic notification: %w", err)
 		}
-		job.Payload = &payload
+		jobs = append(jobs, *job)
 	}
 
-	return &job, nil
+	return jobs, rows.Err()
+}
+
+func (s *PostgresStore) ListUserNotifications(ctx context.Context, userID string, query NotificationListQuery) ([]PublishJob, error) {
+	rows, err := s.db.QueryContext(
+		ctx,
+		`WITH eligible_jobs AS (
+			SELECT
+				pj.id,
+				pj.topic_id,
+				pj.user_id,
+				pj.payload,
+				pj.status,
+				pj.total_count,
+				pj.success_count,
+				pj.failure_count,
+				pj.created_at,
+				pj.completed_at,
+				pj.scheduled_at,
+				COALESCE(pj.scheduled_at, pj.created_at) AS effective_at
+			FROM publish_jobs pj
+			WHERE pj.user_id = $1
+
+			UNION ALL
+
+			SELECT
+				pj.id,
+				pj.topic_id,
+				pj.user_id,
+				pj.payload,
+				pj.status,
+				pj.total_count,
+				pj.success_count,
+				pj.failure_count,
+				pj.created_at,
+				pj.completed_at,
+				pj.scheduled_at,
+				COALESCE(pj.scheduled_at, pj.created_at) AS effective_at
+			FROM publish_jobs pj
+			INNER JOIN user_topic_subscriptions sub
+				ON sub.topic_id = pj.topic_id
+				AND sub.user_id = $1
+			WHERE pj.topic_id IS NOT NULL
+				AND COALESCE(pj.scheduled_at, pj.created_at) >= sub.created_at
+		)
+		SELECT
+			id,
+			COALESCE(topic_id, ''),
+			COALESCE(user_id, ''),
+			payload,
+			status,
+			total_count,
+			success_count,
+			failure_count,
+			created_at,
+			completed_at,
+			scheduled_at
+		FROM eligible_jobs
+		WHERE ($2 = '' OR status = $2)
+			AND (
+				NULLIF($3, '') IS NULL
+				OR (effective_at, id) < (NULLIF($3, '')::timestamptz, $4)
+			)
+		ORDER BY effective_at DESC, id DESC
+		LIMIT $5`,
+		userID,
+		query.Status,
+		query.Cursor.SortValue,
+		query.Cursor.ID,
+		query.Limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error listing user notifications: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []PublishJob
+	for rows.Next() {
+		job, err := scanPublishJob(rows)
+		if err != nil {
+			return nil, fmt.Errorf("error scanning user notification: %w", err)
+		}
+		jobs = append(jobs, *job)
+	}
+
+	return jobs, rows.Err()
 }
 
 func (s *PostgresStore) ApplyPushOutcomeBatch(ctx context.Context, receipts []model.DeliveryReceipt) error {
@@ -688,7 +969,12 @@ func (s *PostgresStore) bulkInsertReceiptsTx(ctx context.Context, tx *sql.Tx, re
 	}
 
 	for _, r := range receipts {
-		if _, err := stmt.ExecContext(ctx, r.ID, r.JobID, r.TokenID, r.Status, r.StatusReason, r.DispatchedAt); err != nil {
+		dispatchedAt, err := parseRequiredPostgresTime(r.DispatchedAt)
+		if err != nil {
+			_ = stmt.Close()
+			return fmt.Errorf("error parsing dispatched_at for job %s token %s: %w", r.JobID, r.TokenID, err)
+		}
+		if _, err := stmt.ExecContext(ctx, r.ID, r.JobID, r.TokenID, r.Status, r.StatusReason, dispatchedAt); err != nil {
 			_ = stmt.Close()
 			return fmt.Errorf("error buffering receipt for job %s token %s: %w", r.JobID, r.TokenID, err)
 		}
@@ -731,8 +1017,13 @@ func (s *PostgresStore) CompleteJobIfDone(ctx context.Context, jobID string) err
 // Delivery receipt operations
 
 func (s *PostgresStore) RecordDeliveryReceipt(ctx context.Context, receipt *model.DeliveryReceipt) error {
+	dispatchedAt, err := parseRequiredPostgresTime(receipt.DispatchedAt)
+	if err != nil {
+		return fmt.Errorf("error parsing dispatched_at: %w", err)
+	}
+
 	query := `INSERT INTO delivery_receipts(id, job_id, token_id, status, status_reason, dispatched_at) VALUES($1, $2, $3, $4, $5, $6)`
-	_, err := s.db.ExecContext(ctx, query, receipt.ID, receipt.JobID, receipt.TokenID, receipt.Status, receipt.StatusReason, receipt.DispatchedAt)
+	_, err = s.db.ExecContext(ctx, query, receipt.ID, receipt.JobID, receipt.TokenID, receipt.Status, receipt.StatusReason, dispatchedAt)
 	return err
 }
 
@@ -748,28 +1039,11 @@ func (s *PostgresStore) GetScheduledJobs(ctx context.Context) ([]PublishJob, err
 
 	var jobs []PublishJob
 	for rows.Next() {
-		var job PublishJob
-		var payloadJSON []byte
-		var completedAt sql.NullTime
-		var scheduledAt sql.NullTime
-		if err := rows.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &job.Status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &completedAt, &scheduledAt); err != nil {
+		job, err := scanPublishJob(rows)
+		if err != nil {
 			return nil, fmt.Errorf("error scanning job: %w", err)
 		}
-		if completedAt.Valid {
-			job.CompletedAt = completedAt.Time.UTC().Format(time.RFC3339)
-		}
-		if scheduledAt.Valid {
-			job.ScheduledAt = scheduledAt.Time.UTC().Format(time.RFC3339)
-		}
-		// Deserialize payload from JSON
-		if len(payloadJSON) > 0 {
-			var payload model.NotificationPayload
-			if err := json.Unmarshal(payloadJSON, &payload); err != nil {
-				return nil, fmt.Errorf("error deserializing payload: %w", err)
-			}
-			job.Payload = &payload
-		}
-		jobs = append(jobs, job)
+		jobs = append(jobs, *job)
 	}
 
 	return jobs, rows.Err()

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -948,7 +948,7 @@ func (s *PostgresStore) bulkInsertReceiptsTx(ctx context.Context, tx *sql.Tx, re
 			_ = stmt.Close()
 			return fmt.Errorf("error parsing dispatched_at for job %s token %s: %w", r.JobID, r.TokenID, err)
 		}
-		if _, err := stmt.ExecContext(ctx, r.ID, r.JobID, r.TokenID, r.Status, r.StatusReason, dispatchedAt); err != nil {
+		if _, err := stmt.ExecContext(ctx, r.ID, r.JobID, r.TokenID, string(r.Status), r.StatusReason, dispatchedAt); err != nil {
 			_ = stmt.Close()
 			return fmt.Errorf("error buffering receipt for job %s token %s: %w", r.JobID, r.TokenID, err)
 		}
@@ -997,7 +997,7 @@ func (s *PostgresStore) RecordDeliveryReceipt(ctx context.Context, receipt *mode
 	}
 
 	query := `INSERT INTO delivery_receipts(id, job_id, token_id, status, status_reason, dispatched_at) VALUES($1, $2, $3, $4, $5, $6)`
-	_, err = s.db.ExecContext(ctx, query, receipt.ID, receipt.JobID, receipt.TokenID, receipt.Status, receipt.StatusReason, dispatchedAt)
+	_, err = s.db.ExecContext(ctx, query, receipt.ID, receipt.JobID, receipt.TokenID, string(receipt.Status), receipt.StatusReason, dispatchedAt)
 	return err
 }
 

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -76,9 +76,6 @@ func scanPublishJob(scanner rowScanner) (*PublishJob, error) {
 	var job PublishJob
 	var payloadJSON []byte
 	var status string
-	var createdAt time.Time
-	var completedAt sql.NullTime
-	var scheduledAt sql.NullTime
 
 	err := scanner.Scan(
 		&job.ID,
@@ -89,22 +86,15 @@ func scanPublishJob(scanner rowScanner) (*PublishJob, error) {
 		&job.TotalCount,
 		&job.SuccessCount,
 		&job.FailureCount,
-		&createdAt,
-		&completedAt,
-		&scheduledAt,
+		scanStorageTime(&job.CreatedAt),
+		scanStorageTime(&job.CompletedAt),
+		scanStorageTime(&job.ScheduledAt),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	job.Status = model.NotificationJobStatus(status)
-	job.CreatedAt = formatStorageTime(createdAt)
-	if completedAt.Valid {
-		job.CompletedAt = formatStorageTime(completedAt.Time)
-	}
-	if scheduledAt.Valid {
-		job.ScheduledAt = formatStorageTime(scheduledAt.Time)
-	}
 
 	if len(payloadJSON) > 0 {
 		var payload model.NotificationPayload
@@ -140,15 +130,13 @@ func (s *PostgresStore) GetUser(ctx context.Context, userID string) (*User, erro
 	row := s.db.QueryRowContext(ctx, query, userID)
 
 	var user User
-	var createdAt time.Time
-	err := row.Scan(&user.ID, &createdAt)
+	err := row.Scan(&user.ID, scanStorageTime(&user.CreatedAt))
 	if err == sql.ErrNoRows {
 		return nil, Errors.NotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error getting user: %w", err)
 	}
-	user.CreatedAt = formatStorageTime(createdAt)
 
 	return &user, nil
 }
@@ -174,11 +162,9 @@ func (s *PostgresStore) ListUsers(ctx context.Context, query PageQuery) ([]User,
 	var users []User
 	for rows.Next() {
 		var user User
-		var createdAt time.Time
-		if err := rows.Scan(&user.ID, &createdAt); err != nil {
+		if err := rows.Scan(&user.ID, scanStorageTime(&user.CreatedAt)); err != nil {
 			return nil, fmt.Errorf("error scanning user: %w", err)
 		}
-		user.CreatedAt = formatStorageTime(createdAt)
 		users = append(users, user)
 	}
 
@@ -229,11 +215,9 @@ func (s *PostgresStore) GetTokensByUserID(ctx context.Context, userID string) ([
 	var tokens []Token
 	for rows.Next() {
 		var token Token
-		var createdAt time.Time
-		if err := rows.Scan(&token.ID, &token.UserID, &token.Platform, &token.Token, &createdAt); err != nil {
+		if err := rows.Scan(&token.ID, &token.UserID, &token.Platform, &token.Token, scanStorageTime(&token.CreatedAt)); err != nil {
 			return nil, fmt.Errorf("error scanning token: %w", err)
 		}
-		token.CreatedAt = formatStorageTime(createdAt)
 		tokens = append(tokens, token)
 	}
 
@@ -505,11 +489,9 @@ func (s *PostgresStore) GetUserSubscriptions(ctx context.Context, userID string)
 	var subs []UserTopicSubscription
 	for rows.Next() {
 		var sub UserTopicSubscription
-		var createdAt time.Time
-		if err := rows.Scan(&sub.ID, &sub.UserID, &sub.TopicID, &createdAt); err != nil {
+		if err := rows.Scan(&sub.ID, &sub.UserID, &sub.TopicID, scanStorageTime(&sub.CreatedAt)); err != nil {
 			return nil, fmt.Errorf("error scanning subscription: %w", err)
 		}
-		sub.CreatedAt = formatStorageTime(createdAt)
 		subs = append(subs, sub)
 	}
 
@@ -529,11 +511,9 @@ func (s *PostgresStore) GetTopicSubscribers(ctx context.Context, topicID string)
 	var users []User
 	for rows.Next() {
 		var user User
-		var createdAt time.Time
-		if err := rows.Scan(&user.ID, &createdAt); err != nil {
+		if err := rows.Scan(&user.ID, scanStorageTime(&user.CreatedAt)); err != nil {
 			return nil, fmt.Errorf("error scanning user: %w", err)
 		}
-		user.CreatedAt = formatStorageTime(createdAt)
 		users = append(users, user)
 	}
 
@@ -566,13 +546,9 @@ func (s *PostgresStore) ListTopicSubscribers(ctx context.Context, topicID string
 	var subscribers []TopicSubscriber
 	for rows.Next() {
 		var subscriber TopicSubscriber
-		var createdAt time.Time
-		var subscribedAt time.Time
-		if err := rows.Scan(&subscriber.ID, &createdAt, &subscribedAt); err != nil {
+		if err := rows.Scan(&subscriber.ID, scanStorageTime(&subscriber.CreatedAt), scanStorageTime(&subscriber.SubscribedAt)); err != nil {
 			return nil, fmt.Errorf("error scanning topic subscriber: %w", err)
 		}
-		subscriber.CreatedAt = formatStorageTime(createdAt)
-		subscriber.SubscribedAt = formatStorageTime(subscribedAt)
 		subscribers = append(subscribers, subscriber)
 	}
 

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -1,0 +1,201 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/mithileshchellappan/pushboy/internal/model"
+)
+
+func newTestPostgresStore(t *testing.T) *PostgresStore {
+	t.Helper()
+
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_DATABASE_URL is not set")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test file path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("change to repo root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+
+	store, err := NewPostgresStore(databaseURL)
+	if err != nil {
+		t.Fatalf("create postgres store: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	_, err = store.db.ExecContext(
+		context.Background(),
+		`TRUNCATE delivery_receipts, publish_jobs, user_topic_subscriptions, tokens, topics, users RESTART IDENTITY CASCADE`,
+	)
+	if err != nil {
+		t.Fatalf("clean postgres test database: %v", err)
+	}
+
+	return store
+}
+
+func TestPostgresNotificationEligibility(t *testing.T) {
+	store := newTestPostgresStore(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	payload := &model.NotificationPayload{Title: "test", Body: "body"}
+
+	if _, err := store.CreateUser(ctx, &User{ID: "user-1"}); err != nil {
+		t.Fatalf("create user-1: %v", err)
+	}
+	if _, err := store.CreateUser(ctx, &User{ID: "user-2"}); err != nil {
+		t.Fatalf("create user-2: %v", err)
+	}
+	if err := store.CreateTopic(ctx, &Topic{ID: "topic-1", Name: "Topic 1"}); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+
+	oldTopicJob := &PublishJob{
+		ID:           "job-old-topic",
+		TopicID:      "topic-1",
+		Payload:      payload,
+		Status:       "COMPLETED",
+		CreatedAt:    base.Format(time.RFC3339),
+		TotalCount:   1,
+		SuccessCount: 1,
+	}
+	if _, err := store.CreatePublishJob(ctx, oldTopicJob); err != nil {
+		t.Fatalf("create old topic job: %v", err)
+	}
+
+	if _, err := store.SubscribeUserToTopic(ctx, &UserTopicSubscription{UserID: "user-1", TopicID: "topic-1"}); err != nil {
+		t.Fatalf("subscribe user: %v", err)
+	}
+
+	directJob := &PublishJob{
+		ID:        "job-direct",
+		UserID:    "user-1",
+		Payload:   payload,
+		Status:    "QUEUED",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if _, err := store.CreateUserPublishJob(ctx, directJob); err != nil {
+		t.Fatalf("create direct job: %v", err)
+	}
+
+	scheduledJob := &PublishJob{
+		ID:          "job-scheduled-topic",
+		TopicID:     "topic-1",
+		Payload:     payload,
+		Status:      "SCHEDULED",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		ScheduledAt: time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339),
+	}
+	if _, err := store.CreatePublishJob(ctx, scheduledJob); err != nil {
+		t.Fatalf("create scheduled topic job: %v", err)
+	}
+
+	jobs, err := store.ListUserNotifications(ctx, "user-1", NotificationListQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("list user notifications: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, job := range jobs {
+		seen[job.ID] = true
+	}
+	if !seen["job-direct"] {
+		t.Fatalf("direct user job was not returned: %+v", jobs)
+	}
+	if !seen["job-scheduled-topic"] {
+		t.Fatalf("eligible scheduled topic job was not returned: %+v", jobs)
+	}
+	if seen["job-old-topic"] {
+		t.Fatalf("topic job before subscription should not be returned: %+v", jobs)
+	}
+
+	user2Jobs, err := store.ListUserNotifications(ctx, "user-2", NotificationListQuery{Limit: 10})
+	if err != nil {
+		t.Fatalf("list unsubscribed user notifications: %v", err)
+	}
+	if len(user2Jobs) != 0 {
+		t.Fatalf("unsubscribed user should not see topic jobs: %+v", user2Jobs)
+	}
+
+	scheduledOnly, err := store.ListUserNotifications(ctx, "user-1", NotificationListQuery{
+		Limit:  10,
+		Status: "SCHEDULED",
+	})
+	if err != nil {
+		t.Fatalf("list scheduled notifications: %v", err)
+	}
+	if len(scheduledOnly) != 1 || scheduledOnly[0].ID != "job-scheduled-topic" {
+		t.Fatalf("unexpected scheduled filter result: %+v", scheduledOnly)
+	}
+}
+
+func TestPostgresTimestampColumnsAreTimestamptz(t *testing.T) {
+	store := newTestPostgresStore(t)
+	ctx := context.Background()
+
+	expected := map[string]string{
+		"users.created_at":                    "timestamp with time zone",
+		"tokens.created_at":                   "timestamp with time zone",
+		"user_topic_subscriptions.created_at": "timestamp with time zone",
+		"publish_jobs.created_at":             "timestamp with time zone",
+		"delivery_receipts.dispatched_at":     "timestamp with time zone",
+	}
+
+	rows, err := store.db.QueryContext(
+		ctx,
+		`SELECT table_name, column_name, data_type
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+			AND (table_name, column_name) IN (
+				('users', 'created_at'),
+				('tokens', 'created_at'),
+				('user_topic_subscriptions', 'created_at'),
+				('publish_jobs', 'created_at'),
+				('delivery_receipts', 'dispatched_at')
+			)`,
+	)
+	if err != nil {
+		t.Fatalf("query timestamp columns: %v", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var tableName string
+		var columnName string
+		var dataType string
+		if err := rows.Scan(&tableName, &columnName, &dataType); err != nil {
+			t.Fatalf("scan timestamp column: %v", err)
+		}
+		key := tableName + "." + columnName
+		if expected[key] != dataType {
+			t.Fatalf("%s: expected %q, got %q", key, expected[key], dataType)
+		}
+		delete(expected, key)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("timestamp column rows: %v", err)
+	}
+	if len(expected) != 0 {
+		t.Fatalf("missing timestamp columns: %+v", expected)
+	}
+}

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -74,7 +74,7 @@ func TestPostgresNotificationEligibility(t *testing.T) {
 		ID:           "job-old-topic",
 		TopicID:      "topic-1",
 		Payload:      payload,
-		Status:       "COMPLETED",
+		Status:       model.NotificationJobStatusCompleted,
 		CreatedAt:    base.Format(time.RFC3339),
 		TotalCount:   1,
 		SuccessCount: 1,
@@ -91,7 +91,7 @@ func TestPostgresNotificationEligibility(t *testing.T) {
 		ID:        "job-direct",
 		UserID:    "user-1",
 		Payload:   payload,
-		Status:    "QUEUED",
+		Status:    model.NotificationJobStatusQueued,
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	if _, err := store.CreateUserPublishJob(ctx, directJob); err != nil {
@@ -102,7 +102,7 @@ func TestPostgresNotificationEligibility(t *testing.T) {
 		ID:          "job-scheduled-topic",
 		TopicID:     "topic-1",
 		Payload:     payload,
-		Status:      "SCHEDULED",
+		Status:      model.NotificationJobStatusScheduled,
 		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
 		ScheduledAt: time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339),
 	}
@@ -139,7 +139,7 @@ func TestPostgresNotificationEligibility(t *testing.T) {
 
 	scheduledOnly, err := store.ListUserNotifications(ctx, "user-1", NotificationListQuery{
 		Limit:  10,
-		Status: "SCHEDULED",
+		Status: model.NotificationJobStatusScheduled,
 	})
 	if err != nil {
 		t.Fatalf("list scheduled notifications: %v", err)

--- a/internal/storage/postgres_integration_test.go
+++ b/internal/storage/postgres_integration_test.go
@@ -158,6 +158,8 @@ func TestPostgresTimestampColumnsAreTimestamptz(t *testing.T) {
 		"tokens.created_at":                   "timestamp with time zone",
 		"user_topic_subscriptions.created_at": "timestamp with time zone",
 		"publish_jobs.created_at":             "timestamp with time zone",
+		"publish_jobs.completed_at":           "timestamp with time zone",
+		"publish_jobs.scheduled_at":           "timestamp with time zone",
 		"delivery_receipts.dispatched_at":     "timestamp with time zone",
 	}
 
@@ -171,6 +173,8 @@ func TestPostgresTimestampColumnsAreTimestamptz(t *testing.T) {
 				('tokens', 'created_at'),
 				('user_topic_subscriptions', 'created_at'),
 				('publish_jobs', 'created_at'),
+				('publish_jobs', 'completed_at'),
+				('publish_jobs', 'scheduled_at'),
 				('delivery_receipts', 'dispatched_at')
 			)`,
 	)
@@ -197,5 +201,32 @@ func TestPostgresTimestampColumnsAreTimestamptz(t *testing.T) {
 	}
 	if len(expected) != 0 {
 		t.Fatalf("missing timestamp columns: %+v", expected)
+	}
+
+	if err := store.CreateTopic(ctx, &Topic{ID: "timestamp-topic", Name: "Timestamp Topic"}); err != nil {
+		t.Fatalf("create timestamp topic: %v", err)
+	}
+	if _, err := store.CreatePublishJob(ctx, &PublishJob{
+		ID:          "timestamp-job",
+		TopicID:     "timestamp-topic",
+		Payload:     &model.NotificationPayload{Title: "timestamp", Body: "shape"},
+		Status:      model.NotificationJobStatusScheduled,
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+		ScheduledAt: time.Now().UTC().Add(time.Hour).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("create timestamp job: %v", err)
+	}
+
+	var effectiveAtType string
+	if err := store.db.QueryRowContext(
+		ctx,
+		`SELECT pg_typeof(COALESCE(scheduled_at, created_at))::text
+		FROM publish_jobs
+		LIMIT 1`,
+	).Scan(&effectiveAtType); err != nil {
+		t.Fatalf("query effective timestamp type: %v", err)
+	}
+	if effectiveAtType != "timestamp with time zone" {
+		t.Fatalf("expected effective notification timestamp to be timestamptz, got %q", effectiveAtType)
 	}
 }

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-func TestFormatPostgresTimePreservesSubsecondPrecision(t *testing.T) {
+func TestFormatStorageTimePreservesSubsecondPrecision(t *testing.T) {
 	input := time.Date(2026, 5, 1, 10, 30, 0, 123456789, time.UTC)
 
-	got := formatPostgresTime(input)
+	got := formatStorageTime(input)
 	if got != "2026-05-01T10:30:00.123456789Z" {
 		t.Fatalf("expected nanosecond precision, got %q", got)
 	}

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -1,0 +1,23 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatPostgresTimePreservesSubsecondPrecision(t *testing.T) {
+	input := time.Date(2026, 5, 1, 10, 30, 0, 123456789, time.UTC)
+
+	got := formatPostgresTime(input)
+	if got != "2026-05-01T10:30:00.123456789Z" {
+		t.Fatalf("expected nanosecond precision, got %q", got)
+	}
+
+	parsed, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		t.Fatalf("parse formatted timestamp: %v", err)
+	}
+	if !parsed.Equal(input) {
+		t.Fatalf("expected parsed time %s to equal input %s", parsed, input)
+	}
+}

--- a/internal/storage/postgres_test.go
+++ b/internal/storage/postgres_test.go
@@ -21,3 +21,22 @@ func TestFormatStorageTimePreservesSubsecondPrecision(t *testing.T) {
 		t.Fatalf("expected parsed time %s to equal input %s", parsed, input)
 	}
 }
+
+func TestScanStorageTimePreservesSubsecondPrecision(t *testing.T) {
+	input := time.Date(2026, 5, 1, 10, 30, 0, 123456789, time.UTC)
+	var got string
+
+	if err := scanStorageTime(&got).Scan(input); err != nil {
+		t.Fatalf("scan timestamp: %v", err)
+	}
+	if got != "2026-05-01T10:30:00.123456789Z" {
+		t.Fatalf("expected nanosecond precision, got %q", got)
+	}
+
+	if err := scanStorageTime(&got).Scan(nil); err != nil {
+		t.Fatalf("scan null timestamp: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected null timestamp to scan as empty string, got %q", got)
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -20,6 +20,8 @@ type SQLiteStore struct {
 	db *sql.DB
 }
 
+var _ Store = (*SQLiteStore)(nil)
+
 func NewSQLStore(dataSourceName string) (*SQLiteStore, error) {
 	db, err := sql.Open("sqlite3", dataSourceName)
 	if err != nil {
@@ -93,6 +95,10 @@ func (s *SQLiteStore) GetUser(ctx context.Context, userID string) (*User, error)
 	}
 
 	return &user, nil
+}
+
+func (s *SQLiteStore) ListUsers(ctx context.Context, query PageQuery) ([]User, error) {
+	return nil, fmt.Errorf("list users is only supported by postgres")
 }
 
 func (s *SQLiteStore) DeleteUser(ctx context.Context, userID string) error {
@@ -371,6 +377,10 @@ func (s *SQLiteStore) GetTopicSubscribers(ctx context.Context, topicID string) (
 	return users, rows.Err()
 }
 
+func (s *SQLiteStore) ListTopicSubscribers(ctx context.Context, topicID string, query PageQuery) ([]TopicSubscriber, error) {
+	return nil, fmt.Errorf("list topic subscribers is only supported by postgres")
+}
+
 func (s *SQLiteStore) GetTopicSubscriberCount(ctx context.Context, topicID string) (int, error) {
 	var count int
 	query := `SELECT COUNT(*) FROM user_topic_subscriptions WHERE topic_id = ?`
@@ -536,6 +546,14 @@ func (s *SQLiteStore) GetJobStatus(ctx context.Context, jobID string) (*PublishJ
 	return &job, nil
 }
 
+func (s *SQLiteStore) ListTopicNotifications(ctx context.Context, topicID string, query NotificationListQuery) ([]PublishJob, error) {
+	return nil, fmt.Errorf("list topic notifications is only supported by postgres")
+}
+
+func (s *SQLiteStore) ListUserNotifications(ctx context.Context, userID string, query NotificationListQuery) ([]PublishJob, error) {
+	return nil, fmt.Errorf("list user notifications is only supported by postgres")
+}
+
 func (s *SQLiteStore) ApplyPushOutcomeBatch(ctx context.Context, receipts []model.DeliveryReceipt) error {
 	if len(receipts) == 0 {
 		return nil
@@ -645,6 +663,10 @@ func (s *SQLiteStore) GetTokenCountForUser(ctx context.Context, userID string) (
 		return 0, fmt.Errorf("error counting user tokens: %w", err)
 	}
 	return count, nil
+}
+
+func (s *SQLiteStore) GetScheduledJobs(ctx context.Context) ([]PublishJob, error) {
+	return nil, fmt.Errorf("scheduled jobs are only supported by postgres")
 }
 
 func (s *SQLiteStore) Close() error {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -402,7 +402,7 @@ func (s *SQLiteStore) CreatePublishJob(ctx context.Context, job *PublishJob) (*P
 
 	query := `INSERT INTO publish_jobs(id, topic_id, payload, status, total_count, success_count, failure_count, created_at) 
 		VALUES(?, ?, ?, ?, ?, ?, ?, ?)`
-	_, err = s.db.ExecContext(ctx, query, job.ID, job.TopicID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, job.CreatedAt)
+	_, err = s.db.ExecContext(ctx, query, job.ID, job.TopicID, payloadJSON, string(job.Status), job.TotalCount, job.SuccessCount, job.FailureCount, job.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("error creating publish job: %w", err)
 	}
@@ -428,7 +428,7 @@ func (s *SQLiteStore) CreateUserPublishJob(ctx context.Context, job *PublishJob)
 	}
 
 	query := `INSERT INTO publish_jobs(id, user_id, payload, status, total_count, success_count, failure_count, created_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?)`
-	_, err = s.db.ExecContext(ctx, query, job.ID, job.UserID, payloadJSON, job.Status, job.TotalCount, job.SuccessCount, job.FailureCount, job.CreatedAt)
+	_, err = s.db.ExecContext(ctx, query, job.ID, job.UserID, payloadJSON, string(job.Status), job.TotalCount, job.SuccessCount, job.FailureCount, job.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("error creating user publish job: %w", err)
 	}
@@ -448,10 +448,12 @@ func (s *SQLiteStore) FetchPendingJobs(ctx context.Context, limit int) ([]Publis
 	for rows.Next() {
 		var job PublishJob
 		var payloadJSON []byte
+		var status string
 		var completedAt sql.NullString
-		if err := rows.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &job.Status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &completedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &completedAt); err != nil {
 			return nil, fmt.Errorf("error scanning job: %w", err)
 		}
+		job.Status = model.NotificationJobStatus(status)
 		if completedAt.Valid {
 			job.CompletedAt = completedAt.String
 		}
@@ -469,14 +471,14 @@ func (s *SQLiteStore) FetchPendingJobs(ctx context.Context, limit int) ([]Publis
 	return jobs, rows.Err()
 }
 
-func (s *SQLiteStore) UpdateJobStatus(ctx context.Context, jobID string, status string) error {
+func (s *SQLiteStore) UpdateJobStatus(ctx context.Context, jobID string, status model.NotificationJobStatus) error {
 	var query string
-	if status == "COMPLETED" {
+	if status == model.NotificationJobStatusCompleted {
 		query = `UPDATE publish_jobs SET status = ?, completed_at = CURRENT_TIMESTAMP WHERE id = ?`
 	} else {
 		query = `UPDATE publish_jobs SET status = ? WHERE id = ?`
 	}
-	_, err := s.db.ExecContext(ctx, query, status, jobID)
+	_, err := s.db.ExecContext(ctx, query, string(status), jobID)
 	return err
 }
 
@@ -526,13 +528,15 @@ func (s *SQLiteStore) GetJobStatus(ctx context.Context, jobID string) (*PublishJ
 
 	var job PublishJob
 	var payloadJSON []byte
-	err := row.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &job.Status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &job.CompletedAt)
+	var status string
+	err := row.Scan(&job.ID, &job.TopicID, &job.UserID, &payloadJSON, &status, &job.TotalCount, &job.SuccessCount, &job.FailureCount, &job.CreatedAt, &job.CompletedAt)
 	if err == sql.ErrNoRows {
 		return nil, Errors.NotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error getting job status: %w", err)
 	}
+	job.Status = model.NotificationJobStatus(status)
 
 	// Deserialize payload from JSON
 	if len(payloadJSON) > 0 {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -618,7 +618,7 @@ func (s *SQLiteStore) bulkInsertReceiptsTx(ctx context.Context, tx *sql.Tx, rece
 	defer stmt.Close()
 
 	for _, r := range receipts {
-		if _, err := stmt.ExecContext(ctx, r.ID, r.JobID, r.TokenID, r.Status, r.StatusReason, r.DispatchedAt); err != nil {
+		if _, err := stmt.ExecContext(ctx, r.ID, r.JobID, r.TokenID, string(r.Status), r.StatusReason, r.DispatchedAt); err != nil {
 			return fmt.Errorf("error inserting receipt for job %s token %s: %w", r.JobID, r.TokenID, err)
 		}
 	}
@@ -652,7 +652,7 @@ func (s *SQLiteStore) CompleteJobIfDone(ctx context.Context, jobID string) error
 
 func (s *SQLiteStore) RecordDeliveryReceipt(ctx context.Context, receipt *model.DeliveryReceipt) error {
 	query := `INSERT INTO delivery_receipts(id, job_id, token_id, status, status_reason, dispatched_at) VALUES(?, ?, ?, ?, ?, ?)`
-	_, err := s.db.ExecContext(ctx, query, receipt.ID, receipt.JobID, receipt.TokenID, receipt.Status, receipt.StatusReason, receipt.DispatchedAt)
+	_, err := s.db.ExecContext(ctx, query, receipt.ID, receipt.JobID, receipt.TokenID, string(receipt.Status), receipt.StatusReason, receipt.DispatchedAt)
 	return err
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -27,7 +27,7 @@ type PageQuery struct {
 type NotificationListQuery struct {
 	Limit  int
 	Cursor PageCursor
-	Status string
+	Status model.NotificationJobStatus
 }
 
 // Token represents a device token for push notifications
@@ -68,7 +68,7 @@ type PublishJob struct {
 	TopicID      string
 	UserID       string
 	Payload      *model.NotificationPayload // Full notification content
-	Status       string
+	Status       model.NotificationJobStatus
 	TotalCount   int
 	SuccessCount int
 	FailureCount int
@@ -172,7 +172,7 @@ type Store interface {
 	CreatePublishJob(ctx context.Context, job *PublishJob) (*PublishJob, error)
 	CreateUserPublishJob(ctx context.Context, job *PublishJob) (*PublishJob, error)
 	FetchPendingJobs(ctx context.Context, limit int) ([]PublishJob, error)
-	UpdateJobStatus(ctx context.Context, jobID string, status string) error
+	UpdateJobStatus(ctx context.Context, jobID string, status model.NotificationJobStatus) error
 	FinalizeJobDispatch(ctx context.Context, jobID string, totalCount int) error
 	GetJobStatus(ctx context.Context, jobID string) (*PublishJob, error)
 	ListTopicNotifications(ctx context.Context, topicID string, query NotificationListQuery) ([]PublishJob, error)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -14,6 +14,22 @@ type User struct {
 	CreatedAt string
 }
 
+type PageCursor struct {
+	SortValue string
+	ID        string
+}
+
+type PageQuery struct {
+	Limit  int
+	Cursor PageCursor
+}
+
+type NotificationListQuery struct {
+	Limit  int
+	Cursor PageCursor
+	Status string
+}
+
 // Token represents a device token for push notifications
 type Token struct {
 	ID        string
@@ -35,6 +51,12 @@ type UserTopicSubscription struct {
 	UserID    string
 	TopicID   string
 	CreatedAt string
+}
+
+type TopicSubscriber struct {
+	ID           string
+	CreatedAt    string
+	SubscribedAt string
 }
 
 // NotificationPayload stores the full notification content as JSON
@@ -122,6 +144,7 @@ type Store interface {
 	// User operations
 	CreateUser(ctx context.Context, user *User) (*User, error)
 	GetUser(ctx context.Context, userID string) (*User, error)
+	ListUsers(ctx context.Context, query PageQuery) ([]User, error)
 	DeleteUser(ctx context.Context, userID string) error
 
 	// Token operations
@@ -142,6 +165,7 @@ type Store interface {
 	UnsubscribeUserFromTopic(ctx context.Context, userID, topicID string) error
 	GetUserSubscriptions(ctx context.Context, userID string) ([]UserTopicSubscription, error)
 	GetTopicSubscribers(ctx context.Context, topicID string) ([]User, error)
+	ListTopicSubscribers(ctx context.Context, topicID string, query PageQuery) ([]TopicSubscriber, error)
 	GetTopicSubscriberCount(ctx context.Context, topicID string) (int, error)
 
 	// Publish job operations
@@ -151,6 +175,8 @@ type Store interface {
 	UpdateJobStatus(ctx context.Context, jobID string, status string) error
 	FinalizeJobDispatch(ctx context.Context, jobID string, totalCount int) error
 	GetJobStatus(ctx context.Context, jobID string) (*PublishJob, error)
+	ListTopicNotifications(ctx context.Context, topicID string, query NotificationListQuery) ([]PublishJob, error)
+	ListUserNotifications(ctx context.Context, userID string, query NotificationListQuery) ([]PublishJob, error)
 	ApplyPushOutcomeBatch(ctx context.Context, receipts []model.DeliveryReceipt) error
 	IncrementJobCounters(ctx context.Context, jobID string, success int, failure int) error
 	CompleteJobIfDone(ctx context.Context, jobID string) error

--- a/internal/storage/time.go
+++ b/internal/storage/time.go
@@ -1,0 +1,31 @@
+package storage
+
+import "time"
+
+func formatStorageTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func parseRequiredStorageTime(value string) (time.Time, error) {
+	if value == "" {
+		return time.Now().UTC(), nil
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t.UTC(), nil
+}
+
+func parseOptionalStorageTime(value string) (any, error) {
+	if value == "" {
+		return nil, nil
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil, err
+	}
+	return t.UTC(), nil
+}

--- a/internal/storage/time.go
+++ b/internal/storage/time.go
@@ -1,9 +1,55 @@
 package storage
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+type storageTimeScanner struct {
+	dest *string
+}
+
+func scanStorageTime(dest *string) storageTimeScanner {
+	return storageTimeScanner{dest: dest}
+}
+
+func (s storageTimeScanner) Scan(value any) error {
+	if s.dest == nil {
+		return fmt.Errorf("nil timestamp destination")
+	}
+
+	switch v := value.(type) {
+	case nil:
+		*s.dest = ""
+		return nil
+	case time.Time:
+		*s.dest = formatStorageTime(v)
+		return nil
+	case string:
+		return scanStorageTimeString(s.dest, v)
+	case []byte:
+		return scanStorageTimeString(s.dest, string(v))
+	default:
+		return fmt.Errorf("cannot scan timestamp value of type %T", value)
+	}
+}
 
 func formatStorageTime(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func scanStorageTimeString(dest *string, value string) error {
+	if value == "" {
+		*dest = ""
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return err
+	}
+	*dest = formatStorageTime(t)
+	return nil
 }
 
 func parseRequiredStorageTime(value string) (time.Time, error) {

--- a/internal/workers/masters.go
+++ b/internal/workers/masters.go
@@ -62,7 +62,7 @@ func (m *MasterWorker) Stop() {
 }
 
 func (m *MasterWorker) fetchAndPushTokens(ctx context.Context, job model.JobItem) error {
-	m.store.UpdateJobStatus(ctx, job.ID, "IN_PROGRESS")
+	m.store.UpdateJobStatus(ctx, job.ID, model.NotificationJobStatusInProgress)
 	cursor := ""
 	totalTokenCount := 0
 	for {
@@ -79,7 +79,7 @@ func (m *MasterWorker) fetchAndPushTokens(ctx context.Context, job model.JobItem
 		log.Printf("fetching tokens for job %v", job.ID)
 		if err != nil {
 			log.Printf("Error fetching tokens: %v", err)
-			m.store.UpdateJobStatus(ctx, job.ID, "FAILED")
+			m.store.UpdateJobStatus(ctx, job.ID, model.NotificationJobStatusFailed)
 			return fmt.Errorf("error fetching tokens: %v", err)
 		}
 		totalTokenCount += len(batch.Tokens)
@@ -105,7 +105,7 @@ func (m *MasterWorker) fetchAndPushTokens(ctx context.Context, job model.JobItem
 	}
 	if err := m.store.FinalizeJobDispatch(ctx, job.ID, totalTokenCount); err != nil {
 		log.Printf("Error finalizing dispatch for job %v: %v", job.ID, err)
-		m.store.UpdateJobStatus(ctx, job.ID, "FAILED")
+		m.store.UpdateJobStatus(ctx, job.ID, model.NotificationJobStatusFailed)
 		return fmt.Errorf("error finalizing dispatch: %v", err)
 	}
 

--- a/internal/workers/masters.go
+++ b/internal/workers/masters.go
@@ -187,7 +187,7 @@ func (m *MasterWorker) pushLATokensToPipeline(ctx context.Context, batch *storag
 				Receipt: model.DeliveryReceipt{
 					JobID:        job.LADispatchID,
 					TokenID:      token.ID,
-					Status:       string(model.Failed),
+					Status:       model.DeliveryStatusFailed,
 					StatusReason: "task enqueue failed",
 					DispatchedAt: time.Now().UTC().Format(time.RFC3339),
 				},

--- a/internal/workers/senders.go
+++ b/internal/workers/senders.go
@@ -66,7 +66,7 @@ func (s *SenderWorker) sendPushTask(ctx context.Context, task model.SendTask) {
 		DispatchedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	if !ok {
-		receipt.Status = string(model.Failed)
+		receipt.Status = model.DeliveryStatusFailed
 		receipt.StatusReason = fmt.Sprintf("Unknown dispatcher platform: %s", task.Target.Platform)
 		s.pushToDLQ(ctx, receipt, task)
 		return
@@ -74,7 +74,7 @@ func (s *SenderWorker) sendPushTask(ctx context.Context, task model.SendTask) {
 
 	pushDispatcher, ok := dispatcher.(dispatch.Dispatcher)
 	if !ok {
-		receipt.Status = string(model.Failed)
+		receipt.Status = model.DeliveryStatusFailed
 		receipt.StatusReason = fmt.Sprintf("Unknown dispatcher platform: %s", task.Target.Platform)
 		s.pushToDLQ(ctx, receipt, task)
 		return
@@ -83,12 +83,12 @@ func (s *SenderWorker) sendPushTask(ctx context.Context, task model.SendTask) {
 	err := pushDispatcher.Send(ctx, task.Target.Token, task.Job.Payload)
 	if err != nil {
 		fmt.Printf("Error sending %s notification, tokenId: %s, error: %v", task.Target.Platform, task.Target.TokenID, err)
-		receipt.Status = string(model.Failed)
+		receipt.Status = model.DeliveryStatusFailed
 		receipt.StatusReason = err.Error()
 		s.pushToDLQ(ctx, receipt, task)
 		return
 	}
-	receipt.Status = string(model.Success)
+	receipt.Status = model.DeliveryStatusSuccess
 	s.pushToDLQ(ctx, receipt, task)
 	return
 }
@@ -102,7 +102,7 @@ func (s *SenderWorker) sendLATask(ctx context.Context, task model.SendTask) {
 		DispatchedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 	if !ok {
-		receipt.Status = string(model.Failed)
+		receipt.Status = model.DeliveryStatusFailed
 		receipt.StatusReason = fmt.Sprintf("Unknown dispatcher platform: %s", task.Target.Platform)
 		s.pushToDLQ(ctx, receipt, task)
 		return
@@ -110,7 +110,7 @@ func (s *SenderWorker) sendLATask(ctx context.Context, task model.SendTask) {
 
 	laDispatcher, ok := dispatcher.(dispatch.LiveActivityDispatcher)
 	if !ok {
-		receipt.Status = string(model.Failed)
+		receipt.Status = model.DeliveryStatusFailed
 		receipt.StatusReason = fmt.Sprintf("No live activity dispatcher configured for platform: %s", task.Target.Platform)
 		s.pushToDLQ(ctx, receipt, task)
 		return
@@ -125,13 +125,13 @@ func (s *SenderWorker) sendLATask(ctx context.Context, task model.SendTask) {
 	})
 	if err != nil {
 		fmt.Printf("Error sending %s live activity, tokenId: %s, error: %v", task.Target.Platform, task.Target.TokenID, err)
-		receipt.Status = string(model.Failed)
+		receipt.Status = model.DeliveryStatusFailed
 		receipt.StatusReason = err.Error()
 		s.pushToDLQ(ctx, receipt, task)
 		return
 	}
 
-	receipt.Status = string(model.Success)
+	receipt.Status = model.DeliveryStatusSuccess
 	s.pushToDLQ(ctx, receipt, task)
 }
 

--- a/pushboy.postman_collection.json
+++ b/pushboy.postman_collection.json
@@ -30,6 +30,21 @@
 			"key": "jobID",
 			"value": "",
 			"type": "string"
+		},
+		{
+			"key": "status",
+			"value": "COMPLETED",
+			"type": "string"
+		},
+		{
+			"key": "limit",
+			"value": "50",
+			"type": "string"
+		},
+		{
+			"key": "cursor",
+			"value": "",
+			"type": "string"
 		}
 	],
 	"item": [
@@ -98,6 +113,31 @@
 							"path": ["v1", "users"]
 						},
 						"description": "Create a new user with an auto-generated UUID."
+					},
+					"response": []
+				},
+				{
+					"name": "List Users",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/v1/users?limit={{limit}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["v1", "users"],
+							"query": [
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "cursor",
+									"value": "{{cursor}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "List users with keyset pagination. Responses use {\"items\": [], \"next_cursor\": \"\", \"has_more\": false}."
 					},
 					"response": []
 				},
@@ -248,7 +288,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"name\": \"announcements\"\n}"
+							"raw": "{\n    \"id\": \"topic:announcements\",\n    \"name\": \"announcements\"\n}"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/v1/topics",
@@ -345,6 +385,31 @@
 							"path": ["v1", "users", "{{userID}}", "subscriptions"]
 						},
 						"description": "Get all topic subscriptions for a user"
+					},
+					"response": []
+				},
+				{
+					"name": "List Topic Subscribers",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/v1/topics/{{topicID}}/subscribers?limit={{limit}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["v1", "topics", "{{topicID}}", "subscribers"],
+							"query": [
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "cursor",
+									"value": "{{cursor}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "List current topic subscribers with keyset pagination."
 					},
 					"response": []
 				}
@@ -469,16 +534,74 @@
 					"response": []
 				},
 				{
-					"name": "Get Publish Job Status",
+					"name": "List Topic Notifications",
 					"request": {
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/topics/{{topicID}}/publish/{{jobID}}",
+							"raw": "{{baseUrl}}/v1/topics/{{topicID}}/notifications?status={{status}}&limit={{limit}}",
 							"host": ["{{baseUrl}}"],
-							"path": ["v1", "topics", "{{topicID}}", "publish", "{{jobID}}"]
+							"path": ["v1", "topics", "{{topicID}}", "notifications"],
+							"query": [
+								{
+									"key": "status",
+									"value": "{{status}}"
+								},
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "cursor",
+									"value": "{{cursor}}",
+									"disabled": true
+								}
+							]
 						},
-						"description": "Get the status of a publish job.\n\nStatus values:\n- QUEUED: Job is waiting to be processed\n- IN_PROGRESS: Job is currently being processed\n- COMPLETED: Job finished processing\n\nAlso returns total_count, success_count, failure_count for delivery stats."
+						"description": "List topic notification jobs with optional exact uppercase status filtering."
+					},
+					"response": []
+				},
+				{
+					"name": "List User Notifications",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/v1/users/{{userID}}/notifications?status={{status}}&limit={{limit}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["v1", "users", "{{userID}}", "notifications"],
+							"query": [
+								{
+									"key": "status",
+									"value": "{{status}}"
+								},
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "cursor",
+									"value": "{{cursor}}",
+									"disabled": true
+								}
+							]
+						},
+						"description": "List notifications a user is currently eligible for: direct sends plus topic sends after the user's subscription time."
+					},
+					"response": []
+				},
+				{
+					"name": "Get Notification Job",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/v1/notifications/{{jobID}}",
+							"host": ["{{baseUrl}}"],
+							"path": ["v1", "notifications", "{{jobID}}"]
+						},
+						"description": "Get a notification job by ID.\n\nStatus values:\n- QUEUED\n- SCHEDULED\n- IN_PROGRESS\n- DISPATCHED\n- COMPLETED\n- FAILED\n\nAlso returns total_count, success_count, failure_count for delivery stats."
 					},
 					"response": []
 				}
@@ -486,5 +609,3 @@
 		}
 	]
 }
-
-


### PR DESCRIPTION
## Summary
- add minimal paginated read/query APIs for users, topic subscribers, topic notifications, user-eligible notifications, and canonical notification lookup
- migrate remaining Postgres text timestamp columns to `TIMESTAMPTZ` and add query indexes
- remove the old topic-scoped notification job lookup route from router, OpenAPI, and Postman

## Notes
- user notification listing is current-subscription eligibility, not delivery history
- SQLite remains compile-only for these new Postgres-first query routes
- closes #33

## Validation
- `go test -count=1 ./...`
- `ruby -e "require 'yaml'; YAML.load_file('docs/openapi.yaml')"`
- `python3 -m json.tool pushboy.postman_collection.json >/tmp/pushboy_postman.json`
