### PR TITLE
Scope Live Activity update fanout by activity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,7 @@ FCM_KEY_PATH=keys/service-account.json
 # ===========================================
 # Users created by the API are automatically subscribed to this topic.
 BROADCAST_TOPIC_NAME=broadcast
+
+# Gate Live Activity update/end fanout to tokens associated with the job activityId.
+# Keep this false until shadow metrics show associated candidate counts are safe.
+LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT=false

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ curl -X POST http://localhost:8080/v1/live-activity/tokens \
   -d '{
     "userId": "user-123",
     "topicId": "orders",
+    "activityId": "order-123",
     "platform": "apns",
     "tokenType": "start",
     "token": "live-activity-token"

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ curl -X POST http://localhost:8080/v1/live-activity/tokens \
     "topicId": "orders",
     "activityId": "order-123",
     "platform": "apns",
-    "tokenType": "start",
-    "token": "live-activity-token"
+    "tokenType": "update",
+    "token": "live-activity-update-token"
   }'
 ```
 

--- a/db/migrations/postgres/000011_add_live_activity_token_activities.down.sql
+++ b/db/migrations/postgres/000011_add_live_activity_token_activities.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS live_activity_token_activities;

--- a/db/migrations/postgres/000011_add_live_activity_token_activities.up.sql
+++ b/db/migrations/postgres/000011_add_live_activity_token_activities.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS live_activity_token_activities (
+    activity_id TEXT NOT NULL,
+    token_id TEXT NOT NULL REFERENCES live_activity_tokens(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    source TEXT NOT NULL,
+    PRIMARY KEY (activity_id, token_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_live_activity_token_activities_token_id
+    ON live_activity_token_activities(token_id);

--- a/db/migrations/postgres/000011_add_live_activity_token_activities.up.sql
+++ b/db/migrations/postgres/000011_add_live_activity_token_activities.up.sql
@@ -3,7 +3,6 @@ CREATE TABLE IF NOT EXISTS live_activity_token_activities (
     token_id TEXT NOT NULL REFERENCES live_activity_tokens(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL,
     last_seen_at TIMESTAMPTZ NOT NULL,
-    source TEXT NOT NULL,
     PRIMARY KEY (activity_id, token_id)
 );
 

--- a/db/migrations/postgres/000012_drop_live_activity_token_activity_source.down.sql
+++ b/db/migrations/postgres/000012_drop_live_activity_token_activity_source.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE live_activity_token_activities ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'unknown';

--- a/db/migrations/postgres/000012_drop_live_activity_token_activity_source.up.sql
+++ b/db/migrations/postgres/000012_drop_live_activity_token_activity_source.up.sql
@@ -1,0 +1,2 @@
+-- 000011 briefly had source while this branch was deployed; keep already-run databases compatible.
+ALTER TABLE live_activity_token_activities DROP COLUMN IF EXISTS source;

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1139,9 +1139,6 @@ components:
           $ref: "#/components/schemas/LiveActivityTokenType"
         Token:
           type: string
-        ActivityID:
-          type: string
-          description: Activity associated by this registration, when provided.
         CreatedAt:
           type: string
         LastSeenAt:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -916,6 +916,10 @@ components:
         topicId:
           type: string
           example: live-orders
+        activityId:
+          type: string
+          description: Associates this token with a specific Live Activity for scoped update/end fanout.
+          example: order-123
         platform:
           $ref: "#/components/schemas/Platform"
         tokenType:
@@ -1135,6 +1139,9 @@ components:
           $ref: "#/components/schemas/LiveActivityTokenType"
         Token:
           type: string
+        ActivityID:
+          type: string
+          description: Activity associated by this registration, when provided.
         CreatedAt:
           type: string
         LastSeenAt:

--- a/internal/server/dto.go
+++ b/internal/server/dto.go
@@ -149,7 +149,6 @@ type laTokenResponse struct {
 	Platform      model.Platform
 	TokenType     model.LiveActivityTokenType
 	Token         string
-	ActivityID    string `json:"ActivityID,omitempty"`
 	CreatedAt     string
 	LastSeenAt    string
 	ExpiresAt     string
@@ -163,7 +162,6 @@ func toLATokenResponse(token storage.LiveActivityToken) laTokenResponse {
 		Platform:      token.Platform,
 		TokenType:     token.TokenType,
 		Token:         token.Token,
-		ActivityID:    token.ActivityID,
 		CreatedAt:     formatAPITime(token.CreatedAt),
 		LastSeenAt:    formatAPITime(token.LastSeenAt),
 		ExpiresAt:     formatAPIOptionalTime(token.ExpiresAt),

--- a/internal/server/dto.go
+++ b/internal/server/dto.go
@@ -149,6 +149,7 @@ type laTokenResponse struct {
 	Platform      model.Platform
 	TokenType     model.LiveActivityTokenType
 	Token         string
+	ActivityID    string `json:"ActivityID,omitempty"`
 	CreatedAt     string
 	LastSeenAt    string
 	ExpiresAt     string
@@ -162,6 +163,7 @@ func toLATokenResponse(token storage.LiveActivityToken) laTokenResponse {
 		Platform:      token.Platform,
 		TokenType:     token.TokenType,
 		Token:         token.Token,
+		ActivityID:    token.ActivityID,
 		CreatedAt:     formatAPITime(token.CreatedAt),
 		LastSeenAt:    formatAPITime(token.LastSeenAt),
 		ExpiresAt:     formatAPIOptionalTime(token.ExpiresAt),

--- a/internal/server/live_activity.go
+++ b/internal/server/live_activity.go
@@ -15,12 +15,13 @@ import (
 )
 
 type registerLiveActivityTokenRequest struct {
-	UserID    string `json:"userId"`
-	TopicID   string `json:"topicId,omitempty"`
-	Platform  string `json:"platform"`
-	TokenType string `json:"tokenType"`
-	Token     string `json:"token"`
-	ExpiresAt string `json:"expiresAt,omitempty"`
+	UserID     string `json:"userId"`
+	TopicID    string `json:"topicId,omitempty"`
+	ActivityID string `json:"activityId,omitempty"`
+	Platform   string `json:"platform"`
+	TokenType  string `json:"tokenType"`
+	Token      string `json:"token"`
+	ExpiresAt  string `json:"expiresAt,omitempty"`
 }
 
 type deleteLiveActivityTokenRequest struct {
@@ -88,6 +89,7 @@ func (s *Server) handleRegisterLAToken(w http.ResponseWriter, r *http.Request) {
 		req.Token,
 		req.TopicID,
 		req.ExpiresAt,
+		req.ActivityID,
 	)
 	if err != nil {
 		switch {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -202,15 +202,6 @@ func TestHandleRegisterLATokenStoresActivityID(t *testing.T) {
 	if recorder.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
 	}
-	var response struct {
-		Token *laTokenResponse
-	}
-	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if response.Token == nil || response.Token.ActivityID != "session-1_2026" {
-		t.Fatalf("response.Token = %+v", response.Token)
-	}
 }
 
 func testRouter(t *testing.T, store storage.Store, jobPipeline pipeline.Pipeline[model.JobItem]) http.Handler {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -152,6 +152,67 @@ func TestHandleSendToUserNotificationValidation(t *testing.T) {
 	})
 }
 
+func TestHandleRegisterLATokenStoresActivityID(t *testing.T) {
+	now := time.Now().UTC()
+	store := &serverStoreStub{t: t}
+	store.getUserFunc = func(ctx context.Context, userID string) (*storage.User, error) {
+		if userID != "user-1" {
+			t.Fatalf("GetUser userID = %q, want user-1", userID)
+		}
+		return &storage.User{ID: userID, CreatedAt: now}, nil
+	}
+	store.getTopicByIDFunc = func(ctx context.Context, topicID string) (*storage.Topic, error) {
+		if topicID != "broadcast" {
+			t.Fatalf("GetTopicByID topicID = %q, want broadcast", topicID)
+		}
+		return &storage.Topic{ID: topicID, Name: topicID}, nil
+	}
+	store.subscribeUserToLATopicFunc = func(ctx context.Context, sub *storage.LiveActivityUserTopicSubscription) (*storage.LiveActivityUserTopicSubscription, error) {
+		if sub.UserID != "user-1" || sub.TopicID != "broadcast" {
+			t.Fatalf("SubscribeUserToLATopic sub = %+v", sub)
+		}
+		return sub, nil
+	}
+	store.upsertLiveActivityTokenFunc = func(ctx context.Context, token *storage.LiveActivityToken) (*storage.LiveActivityToken, error) {
+		if token.UserID != "user-1" || token.Platform != model.APNS || token.TokenType != model.LiveActivityTokenTypeUpdate || token.Token != "la-token" {
+			t.Fatalf("UpsertLiveActivityToken token = %+v", token)
+		}
+		if token.ActivityID != "session-1_2026" {
+			t.Fatalf("UpsertLiveActivityToken ActivityID = %q, want session-1_2026", token.ActivityID)
+		}
+		token.ID = "token-id"
+		token.CreatedAt = now
+		token.LastSeenAt = now
+		return token, nil
+	}
+
+	router := testRouter(t, store, &serverJobPipeline{t: t, failOnSubmit: true})
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/live-activity/tokens", bytes.NewBufferString(`{
+		"userId":"user-1",
+		"topicId":"broadcast",
+		"activityId":"session-1_2026",
+		"platform":"apns",
+		"tokenType":"update",
+		"token":"la-token"
+	}`))
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d, body: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	var response struct {
+		Token *laTokenResponse
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.Token == nil || response.Token.ActivityID != "session-1_2026" {
+		t.Fatalf("response.Token = %+v", response.Token)
+	}
+}
+
 func testRouter(t *testing.T, store storage.Store, jobPipeline pipeline.Pipeline[model.JobItem]) http.Handler {
 	t.Helper()
 
@@ -188,11 +249,14 @@ func (p *serverJobPipeline) Close(ctx context.Context) error {
 type serverStoreStub struct {
 	t *testing.T
 
-	getUserFunc              func(context.Context, string) (*storage.User, error)
-	createUserFunc           func(context.Context, *storage.User) (*storage.User, error)
-	createTokenFunc          func(context.Context, *storage.Token) (*storage.Token, error)
-	createUserPublishJobFunc func(context.Context, *storage.PublishJob) (*storage.PublishJob, error)
-	updateJobStatusFunc      func(context.Context, string, model.NotificationJobStatus) error
+	getUserFunc                 func(context.Context, string) (*storage.User, error)
+	getTopicByIDFunc            func(context.Context, string) (*storage.Topic, error)
+	createUserFunc              func(context.Context, *storage.User) (*storage.User, error)
+	createTokenFunc             func(context.Context, *storage.Token) (*storage.Token, error)
+	upsertLiveActivityTokenFunc func(context.Context, *storage.LiveActivityToken) (*storage.LiveActivityToken, error)
+	subscribeUserToLATopicFunc  func(context.Context, *storage.LiveActivityUserTopicSubscription) (*storage.LiveActivityUserTopicSubscription, error)
+	createUserPublishJobFunc    func(context.Context, *storage.PublishJob) (*storage.PublishJob, error)
+	updateJobStatusFunc         func(context.Context, string, model.NotificationJobStatus) error
 }
 
 func (s *serverStoreStub) unused(method string) {
@@ -267,6 +331,9 @@ func (s *serverStoreStub) ListTopics(ctx context.Context) ([]storage.Topic, erro
 }
 
 func (s *serverStoreStub) GetTopicByID(ctx context.Context, topicID string) (*storage.Topic, error) {
+	if s.getTopicByIDFunc != nil {
+		return s.getTopicByIDFunc(ctx, topicID)
+	}
 	s.unused("GetTopicByID")
 	return nil, errors.New("unexpected GetTopicByID")
 }
@@ -398,6 +465,9 @@ func (s *serverStoreStub) GetScheduledJobs(ctx context.Context) ([]storage.Publi
 }
 
 func (s *serverStoreStub) UpsertLiveActivityToken(ctx context.Context, token *storage.LiveActivityToken) (*storage.LiveActivityToken, error) {
+	if s.upsertLiveActivityTokenFunc != nil {
+		return s.upsertLiveActivityTokenFunc(ctx, token)
+	}
 	s.unused("UpsertLiveActivityToken")
 	return nil, errors.New("unexpected UpsertLiveActivityToken")
 }
@@ -408,6 +478,9 @@ func (s *serverStoreStub) InvalidateLiveActivityToken(ctx context.Context, userI
 }
 
 func (s *serverStoreStub) SubscribeUserToLATopic(ctx context.Context, sub *storage.LiveActivityUserTopicSubscription) (*storage.LiveActivityUserTopicSubscription, error) {
+	if s.subscribeUserToLATopicFunc != nil {
+		return s.subscribeUserToLATopicFunc(ctx, sub)
+	}
 	s.unused("SubscribeUserToLATopic")
 	return nil, errors.New("unexpected SubscribeUserToLATopic")
 }

--- a/internal/service/live_activity.go
+++ b/internal/service/live_activity.go
@@ -56,13 +56,14 @@ func laExpired(expiresAt *time.Time, now time.Time) bool {
 	return !expiresAt.After(now)
 }
 
-func (s *PushboyService) RegisterLAToken(ctx context.Context, userID string, platform model.Platform, tokenType model.LiveActivityTokenType, tokenValue string, topicID string, expiresAt string) (*storage.LiveActivityToken, *storage.User, error) {
+func (s *PushboyService) RegisterLAToken(ctx context.Context, userID string, platform model.Platform, tokenType model.LiveActivityTokenType, tokenValue string, topicID string, expiresAt string, activityID string) (*storage.LiveActivityToken, *storage.User, error) {
 	if userID == "" {
 		return nil, nil, fmt.Errorf("userId is required")
 	}
 	if tokenValue == "" {
 		return nil, nil, fmt.Errorf("token is required")
 	}
+	activityID = strings.TrimSpace(activityID)
 
 	now := time.Now().UTC()
 	expiryTime, err := parseLAExpiry(expiresAt, now)
@@ -108,6 +109,7 @@ func (s *PushboyService) RegisterLAToken(ctx context.Context, userID string, pla
 		Platform:   platform,
 		TokenType:  tokenType,
 		Token:      tokenValue,
+		ActivityID: activityID,
 		ExpiresAt:  expiryTime,
 		CreatedAt:  now,
 		LastSeenAt: now,

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -674,6 +674,17 @@ func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatch
 			OR
 			(
 				lad.action <> 'start'
+				AND (
+					(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
+					OR
+					(
+						laj.topic_id IS NOT NULL AND lat.user_id IN (
+							SELECT user_id
+							FROM live_activity_user_topic_subscriptions
+							WHERE topic_id = laj.topic_id
+						)
+					)
+				)
 				AND EXISTS (
 					SELECT 1
 					FROM live_activity_token_activities lata
@@ -770,6 +781,17 @@ func (s *PostgresStore) logLAScopedFanoutShadow(ctx context.Context, dispatchID 
 		            (lat.platform = 'apns' AND lat.token_type = CASE WHEN d.action = 'start' THEN 'start' ELSE 'update' END)
 		            OR
 		            (lat.platform = 'fcm' AND lat.token_type = 'update')
+		          )
+		          AND (
+		            (d.user_id IS NOT NULL AND lat.user_id = d.user_id)
+		            OR
+		            (
+		              d.topic_id IS NOT NULL AND lat.user_id IN (
+		                SELECT user_id
+		                FROM live_activity_user_topic_subscriptions
+		                WHERE topic_id = d.topic_id
+		              )
+		            )
 		          )
 		       ) AS associated_candidates
 		FROM dispatch d`,

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -138,6 +138,7 @@ func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *Live
 		token.CreatedAt = token.CreatedAt.UTC()
 	}
 	token.LastSeenAt = now
+	activityID := strings.TrimSpace(token.ActivityID)
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -145,25 +146,6 @@ func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *Live
 	}
 	defer tx.Rollback()
 
-	stored, err := upsertLiveActivityTokenTx(ctx, tx, token)
-	if err != nil {
-		return nil, err
-	}
-
-	if strings.TrimSpace(token.ActivityID) != "" {
-		if err := associateLiveActivityTokenTx(ctx, tx, strings.TrimSpace(token.ActivityID), stored.ID, now, "registration"); err != nil {
-			return nil, err
-		}
-		stored.ActivityID = strings.TrimSpace(token.ActivityID)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("error committing LA token upsert transaction: %w", err)
-	}
-	return stored, nil
-}
-
-func upsertLiveActivityTokenTx(ctx context.Context, tx *sql.Tx, token *LiveActivityToken) (*LiveActivityToken, error) {
 	row := tx.QueryRowContext(
 		ctx,
 		`INSERT INTO live_activity_tokens(
@@ -191,32 +173,38 @@ func upsertLiveActivityTokenTx(ctx context.Context, tx *sql.Tx, token *LiveActiv
 	if err := scanLAToken(row, &stored); err != nil {
 		return nil, fmt.Errorf("error upserting LA token: %w", err)
 	}
+
+	if activityID != "" {
+		if err := associateLiveActivityTokenTx(ctx, tx, activityID, stored.ID, now); err != nil {
+			return nil, err
+		}
+		stored.ActivityID = activityID
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("error committing LA token upsert transaction: %w", err)
+	}
 	return &stored, nil
 }
 
-func associateLiveActivityTokenTx(ctx context.Context, tx *sql.Tx, activityID string, tokenID string, lastSeenAt time.Time, source string) error {
-	activityID = strings.TrimSpace(activityID)
-	tokenID = strings.TrimSpace(tokenID)
-	source = strings.TrimSpace(source)
-	if activityID == "" || tokenID == "" {
-		return nil
+func associateLiveActivityTokenTx(ctx context.Context, tx *sql.Tx, activityID string, tokenID string, lastSeenAt time.Time) error {
+	if activityID == "" {
+		return fmt.Errorf("activityID is required for LA token association")
 	}
-	if source == "" {
-		source = "unknown"
+	if tokenID == "" {
+		return fmt.Errorf("tokenID is required for LA token association")
 	}
 
 	if _, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO live_activity_token_activities(activity_id, token_id, created_at, last_seen_at, source)
-		 VALUES($1, $2, $3, $3, $4)
+		`INSERT INTO live_activity_token_activities(activity_id, token_id, created_at, last_seen_at)
+		 VALUES($1, $2, $3, $3)
 		 ON CONFLICT (activity_id, token_id)
 		 DO UPDATE SET
-		    last_seen_at = EXCLUDED.last_seen_at,
-		    source = EXCLUDED.source`,
+		    last_seen_at = EXCLUDED.last_seen_at`,
 		activityID,
 		tokenID,
 		lastSeenAt.UTC(),
-		source,
 	); err != nil {
 		return fmt.Errorf("error associating LA token with activity: %w", err)
 	}
@@ -611,8 +599,23 @@ func (s *PostgresStore) UpdateLADispatchStatus(ctx context.Context, dispatchID s
 }
 
 func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatchID string, cursor string, batchSize int) (*LiveActivityTokenBatch, error) {
-	if cursor == "" && !liveActivityScopedUpdateFanoutEnabled() {
+	scopedFanout := liveActivityScopedUpdateFanoutEnabled()
+	if cursor == "" && !scopedFanout {
 		s.logLAScopedFanoutShadow(ctx, dispatchID)
+	}
+
+	activityFilter := ""
+	if scopedFanout {
+		activityFilter = `
+	   AND (
+		lad.action = 'start'
+		OR EXISTS (
+			SELECT 1
+			FROM live_activity_token_activities lata
+			WHERE lata.activity_id = laj.activity_id
+			  AND lata.token_id = lat.id
+		)
+	   )`
 	}
 
 	query := `SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
@@ -630,72 +633,17 @@ func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatch
 	   AND lat.id > $2
 	   AND (
 		(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
-		OR
-		(
-			laj.topic_id IS NOT NULL AND lat.user_id IN (
+		OR (
+			laj.topic_id IS NOT NULL
+			AND lat.user_id IN (
 				SELECT user_id
 				FROM live_activity_user_topic_subscriptions
 				WHERE topic_id = laj.topic_id
 			)
 		)
-	   )
+	   )` + activityFilter + `
 	 ORDER BY lat.id
 	 LIMIT $3`
-
-	if liveActivityScopedUpdateFanoutEnabled() {
-		query = `SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
-		 FROM live_activity_dispatches lad
-		 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
-		 JOIN live_activity_tokens lat
-		   ON lat.invalidated_at IS NULL
-		  AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
-		  AND (
-			(lat.platform = 'apns' AND lat.token_type = CASE WHEN lad.action = 'start' THEN 'start' ELSE 'update' END)
-			OR
-			(lat.platform = 'fcm' AND lat.token_type = 'update')
-		  )
-		 WHERE lad.id = $1
-		   AND lat.id > $2
-		   AND (
-			(
-				lad.action = 'start'
-				AND (
-					(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
-					OR
-					(
-						laj.topic_id IS NOT NULL AND lat.user_id IN (
-							SELECT user_id
-							FROM live_activity_user_topic_subscriptions
-							WHERE topic_id = laj.topic_id
-						)
-					)
-				)
-			)
-			OR
-			(
-				lad.action <> 'start'
-				AND (
-					(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
-					OR
-					(
-						laj.topic_id IS NOT NULL AND lat.user_id IN (
-							SELECT user_id
-							FROM live_activity_user_topic_subscriptions
-							WHERE topic_id = laj.topic_id
-						)
-					)
-				)
-				AND EXISTS (
-					SELECT 1
-					FROM live_activity_token_activities lata
-					WHERE lata.activity_id = laj.activity_id
-					  AND lata.token_id = lat.id
-				)
-			)
-		   )
-		 ORDER BY lat.id
-		 LIMIT $3`
-	}
 
 	rows, err := s.db.QueryContext(
 		ctx,
@@ -739,60 +687,42 @@ func (s *PostgresStore) logLAScopedFanoutShadow(ctx context.Context, dispatchID 
 	err := s.db.QueryRowContext(
 		ctx,
 		`WITH dispatch AS (
-			SELECT lad.action, laj.activity_id, laj.user_id, laj.topic_id
-			FROM live_activity_dispatches lad
-			JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
-			WHERE lad.id = $1
-			  AND lad.action <> 'start'
+			 SELECT lad.action, laj.activity_id, laj.user_id, laj.topic_id
+			 FROM live_activity_dispatches lad
+			 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
+			 WHERE lad.id = $1
+			   AND lad.action <> 'start'
+		),
+		scoped_tokens AS (
+			 SELECT d.activity_id, lat.id
+			 FROM dispatch d
+			 JOIN live_activity_tokens lat
+			   ON lat.invalidated_at IS NULL
+			  AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
+			  AND (
+				(lat.platform = 'apns' AND lat.token_type = 'update')
+				OR
+				(lat.platform = 'fcm' AND lat.token_type = 'update')
+			  )
+			 WHERE (d.user_id IS NOT NULL AND lat.user_id = d.user_id)
+			    OR (
+				d.topic_id IS NOT NULL
+				AND lat.user_id IN (
+					SELECT user_id
+					FROM live_activity_user_topic_subscriptions
+					WHERE topic_id = d.topic_id
+				)
+			    )
 		)
 		SELECT d.action,
 		       d.activity_id,
+		       (SELECT COUNT(*) FROM scoped_tokens) AS broadcast_candidates,
 		       (
-		        SELECT COUNT(*)
-		        FROM live_activity_tokens lat
-		        WHERE lat.invalidated_at IS NULL
-		          AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
-		          AND (
-		            (lat.platform = 'apns' AND lat.token_type = CASE WHEN d.action = 'start' THEN 'start' ELSE 'update' END)
-		            OR
-		            (lat.platform = 'fcm' AND lat.token_type = 'update')
-		          )
-		          AND (
-		            (d.user_id IS NOT NULL AND lat.user_id = d.user_id)
-		            OR
-		            (
-		              d.topic_id IS NOT NULL AND lat.user_id IN (
-		                SELECT user_id
-		                FROM live_activity_user_topic_subscriptions
-		                WHERE topic_id = d.topic_id
-		              )
-		            )
-		          )
-		       ) AS broadcast_candidates,
-		       (
-		        SELECT COUNT(*)
-		        FROM live_activity_tokens lat
-		        JOIN live_activity_token_activities lata
-		          ON lata.token_id = lat.id
-		         AND lata.activity_id = d.activity_id
-		        WHERE lat.invalidated_at IS NULL
-		          AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
-		          AND (
-		            (lat.platform = 'apns' AND lat.token_type = CASE WHEN d.action = 'start' THEN 'start' ELSE 'update' END)
-		            OR
-		            (lat.platform = 'fcm' AND lat.token_type = 'update')
-		          )
-		          AND (
-		            (d.user_id IS NOT NULL AND lat.user_id = d.user_id)
-		            OR
-		            (
-		              d.topic_id IS NOT NULL AND lat.user_id IN (
-		                SELECT user_id
-		                FROM live_activity_user_topic_subscriptions
-		                WHERE topic_id = d.topic_id
-		              )
-		            )
-		          )
+			SELECT COUNT(*)
+			FROM scoped_tokens st
+			JOIN live_activity_token_activities lata
+			  ON lata.token_id = st.id
+			 AND lata.activity_id = st.activity_id
 		       ) AS associated_candidates
 		FROM dispatch d`,
 		dispatchID,
@@ -818,12 +748,6 @@ func (s *PostgresStore) logLAScopedFanoutShadow(ctx context.Context, dispatchID 
 type laOutcomeDelta struct {
 	success int
 	failure int
-}
-
-type laTokenActivityAssociation struct {
-	tokenID    string
-	activityID string
-	source     string
 }
 
 func (s *PostgresStore) CompleteLADispatchEnqueue(ctx context.Context, dispatchID string, totalCount int) error {
@@ -870,12 +794,25 @@ func (s *PostgresStore) ApplyLAOutcomeBatch(ctx context.Context, outcomes []mode
 	}
 	defer tx.Rollback()
 
-	deltas, invalidTokenIDs, tokenActivities := summarizeLAOutcomes(outcomes)
+	deltas, invalidTokenIDs := summarizeLAOutcomes(outcomes)
 	if err := invalidateLATokensTx(ctx, tx, invalidTokenIDs); err != nil {
 		return err
 	}
-	if err := associateLATokensTx(ctx, tx, tokenActivities, time.Now().UTC()); err != nil {
-		return err
+
+	lastSeenAt := time.Now().UTC()
+	for _, outcome := range outcomes {
+		if outcome.Receipt.Status != model.DeliveryStatusSuccess ||
+			outcome.Task.Job == nil ||
+			outcome.Task.Job.LAAction != model.LiveActivityActionStart ||
+			outcome.Task.Job.LAActivityID == "" ||
+			outcome.Task.Target.Platform != model.FCM ||
+			outcome.Receipt.TokenID == "" {
+			continue
+		}
+
+		if err := associateLiveActivityTokenTx(ctx, tx, outcome.Task.Job.LAActivityID, outcome.Receipt.TokenID, lastSeenAt); err != nil {
+			return err
+		}
 	}
 
 	if err := applyLAOutcomeDeltasTx(ctx, tx, deltas); err != nil {
@@ -918,10 +855,9 @@ func (s *PostgresStore) completeEmptyLADispatch(ctx context.Context, dispatchID 
 	return nil
 }
 
-func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelta, map[string]struct{}, []laTokenActivityAssociation) {
+func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelta, map[string]struct{}) {
 	deltas := make(map[string]laOutcomeDelta)
 	invalidTokenIDs := make(map[string]struct{})
-	tokenActivities := make([]laTokenActivityAssociation, 0)
 
 	for _, outcome := range outcomes {
 		dispatchID := outcome.Receipt.JobID
@@ -929,17 +865,6 @@ func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelt
 		switch outcome.Receipt.Status {
 		case model.DeliveryStatusSuccess:
 			delta.success++
-			if outcome.Task.Job != nil &&
-				outcome.Task.Job.LAAction == model.LiveActivityActionStart &&
-				outcome.Task.Job.LAActivityID != "" &&
-				outcome.Task.Target.Platform == model.FCM &&
-				outcome.Receipt.TokenID != "" {
-				tokenActivities = append(tokenActivities, laTokenActivityAssociation{
-					tokenID:    outcome.Receipt.TokenID,
-					activityID: outcome.Task.Job.LAActivityID,
-					source:     "start_dispatch",
-				})
-			}
 		case model.DeliveryStatusFailed:
 			delta.failure++
 			if isLAInvalidToken(outcome.Receipt.StatusReason) {
@@ -949,7 +874,7 @@ func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelt
 		deltas[dispatchID] = delta
 	}
 
-	return deltas, invalidTokenIDs, tokenActivities
+	return deltas, invalidTokenIDs
 }
 
 func invalidateLATokensTx(ctx context.Context, tx *sql.Tx, invalidTokenIDs map[string]struct{}) error {
@@ -970,33 +895,6 @@ func invalidateLATokensTx(ctx context.Context, tx *sql.Tx, invalidTokenIDs map[s
 		pq.Array(tokenIDs),
 	); err != nil {
 		return fmt.Errorf("error invalidating LA tokens: %w", err)
-	}
-	return nil
-}
-
-func associateLATokensTx(ctx context.Context, tx *sql.Tx, associations []laTokenActivityAssociation, lastSeenAt time.Time) error {
-	if len(associations) == 0 {
-		return nil
-	}
-
-	seen := make(map[string]struct{}, len(associations))
-	for _, association := range associations {
-		key := association.activityID + "\x00" + association.tokenID
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-
-		if err := associateLiveActivityTokenTx(
-			ctx,
-			tx,
-			association.activityID,
-			association.tokenID,
-			lastSeenAt,
-			association.source,
-		); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -107,6 +109,7 @@ func scanLAJob(scanner interface{ Scan(dest ...any) error }, job *LiveActivityJo
 
 func isLAInvalidToken(reason string) bool {
 	return strings.Contains(reason, "BadDeviceToken") ||
+		strings.Contains(reason, "ExpiredToken") ||
 		strings.Contains(reason, "Unregistered") ||
 		strings.Contains(reason, "registration-token-not-registered")
 }
@@ -117,6 +120,11 @@ func laConstraint(err error) string {
 		return pqErr.Constraint
 	}
 	return ""
+}
+
+func liveActivityScopedUpdateFanoutEnabled() bool {
+	value := strings.TrimSpace(os.Getenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT"))
+	return value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes")
 }
 
 func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *LiveActivityToken) (*LiveActivityToken, error) {
@@ -131,7 +139,32 @@ func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *Live
 	}
 	token.LastSeenAt = now
 
-	row := s.db.QueryRowContext(
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error starting LA token upsert transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stored, err := upsertLiveActivityTokenTx(ctx, tx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(token.ActivityID) != "" {
+		if err := associateLiveActivityTokenTx(ctx, tx, strings.TrimSpace(token.ActivityID), stored.ID, now, "registration"); err != nil {
+			return nil, err
+		}
+		stored.ActivityID = strings.TrimSpace(token.ActivityID)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("error committing LA token upsert transaction: %w", err)
+	}
+	return stored, nil
+}
+
+func upsertLiveActivityTokenTx(ctx context.Context, tx *sql.Tx, token *LiveActivityToken) (*LiveActivityToken, error) {
+	row := tx.QueryRowContext(
 		ctx,
 		`INSERT INTO live_activity_tokens(
 			id, user_id, platform, token_type, token, created_at, last_seen_at, expires_at, invalidated_at
@@ -159,6 +192,35 @@ func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *Live
 		return nil, fmt.Errorf("error upserting LA token: %w", err)
 	}
 	return &stored, nil
+}
+
+func associateLiveActivityTokenTx(ctx context.Context, tx *sql.Tx, activityID string, tokenID string, lastSeenAt time.Time, source string) error {
+	activityID = strings.TrimSpace(activityID)
+	tokenID = strings.TrimSpace(tokenID)
+	source = strings.TrimSpace(source)
+	if activityID == "" || tokenID == "" {
+		return nil
+	}
+	if source == "" {
+		source = "unknown"
+	}
+
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO live_activity_token_activities(activity_id, token_id, created_at, last_seen_at, source)
+		 VALUES($1, $2, $3, $3, $4)
+		 ON CONFLICT (activity_id, token_id)
+		 DO UPDATE SET
+		    last_seen_at = EXCLUDED.last_seen_at,
+		    source = EXCLUDED.source`,
+		activityID,
+		tokenID,
+		lastSeenAt.UTC(),
+		source,
+	); err != nil {
+		return fmt.Errorf("error associating LA token with activity: %w", err)
+	}
+	return nil
 }
 
 func (s *PostgresStore) InvalidateLiveActivityToken(ctx context.Context, userID string, tokenValue string) error {
@@ -549,9 +611,39 @@ func (s *PostgresStore) UpdateLADispatchStatus(ctx context.Context, dispatchID s
 }
 
 func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatchID string, cursor string, batchSize int) (*LiveActivityTokenBatch, error) {
-	rows, err := s.db.QueryContext(
-		ctx,
-		`SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
+	if cursor == "" && !liveActivityScopedUpdateFanoutEnabled() {
+		s.logLAScopedFanoutShadow(ctx, dispatchID)
+	}
+
+	query := `SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
+	 FROM live_activity_dispatches lad
+	 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
+	 JOIN live_activity_tokens lat
+	   ON lat.invalidated_at IS NULL
+	  AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
+	  AND (
+		(lat.platform = 'apns' AND lat.token_type = CASE WHEN lad.action = 'start' THEN 'start' ELSE 'update' END)
+		OR
+		(lat.platform = 'fcm' AND lat.token_type = 'update')
+	  )
+	 WHERE lad.id = $1
+	   AND lat.id > $2
+	   AND (
+		(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
+		OR
+		(
+			laj.topic_id IS NOT NULL AND lat.user_id IN (
+				SELECT user_id
+				FROM live_activity_user_topic_subscriptions
+				WHERE topic_id = laj.topic_id
+			)
+		)
+	   )
+	 ORDER BY lat.id
+	 LIMIT $3`
+
+	if liveActivityScopedUpdateFanoutEnabled() {
+		query = `SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
 		 FROM live_activity_dispatches lad
 		 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
 		 JOIN live_activity_tokens lat
@@ -565,18 +657,38 @@ func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatch
 		 WHERE lad.id = $1
 		   AND lat.id > $2
 		   AND (
-			(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
+			(
+				lad.action = 'start'
+				AND (
+					(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
+					OR
+					(
+						laj.topic_id IS NOT NULL AND lat.user_id IN (
+							SELECT user_id
+							FROM live_activity_user_topic_subscriptions
+							WHERE topic_id = laj.topic_id
+						)
+					)
+				)
+			)
 			OR
 			(
-				laj.topic_id IS NOT NULL AND lat.user_id IN (
-					SELECT user_id
-					FROM live_activity_user_topic_subscriptions
-					WHERE topic_id = laj.topic_id
+				lad.action <> 'start'
+				AND EXISTS (
+					SELECT 1
+					FROM live_activity_token_activities lata
+					WHERE lata.activity_id = laj.activity_id
+					  AND lata.token_id = lat.id
 				)
 			)
 		   )
 		 ORDER BY lat.id
-		 LIMIT $3`,
+		 LIMIT $3`
+	}
+
+	rows, err := s.db.QueryContext(
+		ctx,
+		query,
 		dispatchID,
 		cursor,
 		batchSize+1,
@@ -607,9 +719,89 @@ func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatch
 	return batch, nil
 }
 
+func (s *PostgresStore) logLAScopedFanoutShadow(ctx context.Context, dispatchID string) {
+	var action string
+	var activityID string
+	var broadcastCandidates int
+	var associatedCandidates int
+
+	err := s.db.QueryRowContext(
+		ctx,
+		`WITH dispatch AS (
+			SELECT lad.action, laj.activity_id, laj.user_id, laj.topic_id
+			FROM live_activity_dispatches lad
+			JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
+			WHERE lad.id = $1
+			  AND lad.action <> 'start'
+		)
+		SELECT d.action,
+		       d.activity_id,
+		       (
+		        SELECT COUNT(*)
+		        FROM live_activity_tokens lat
+		        WHERE lat.invalidated_at IS NULL
+		          AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
+		          AND (
+		            (lat.platform = 'apns' AND lat.token_type = CASE WHEN d.action = 'start' THEN 'start' ELSE 'update' END)
+		            OR
+		            (lat.platform = 'fcm' AND lat.token_type = 'update')
+		          )
+		          AND (
+		            (d.user_id IS NOT NULL AND lat.user_id = d.user_id)
+		            OR
+		            (
+		              d.topic_id IS NOT NULL AND lat.user_id IN (
+		                SELECT user_id
+		                FROM live_activity_user_topic_subscriptions
+		                WHERE topic_id = d.topic_id
+		              )
+		            )
+		          )
+		       ) AS broadcast_candidates,
+		       (
+		        SELECT COUNT(*)
+		        FROM live_activity_tokens lat
+		        JOIN live_activity_token_activities lata
+		          ON lata.token_id = lat.id
+		         AND lata.activity_id = d.activity_id
+		        WHERE lat.invalidated_at IS NULL
+		          AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
+		          AND (
+		            (lat.platform = 'apns' AND lat.token_type = CASE WHEN d.action = 'start' THEN 'start' ELSE 'update' END)
+		            OR
+		            (lat.platform = 'fcm' AND lat.token_type = 'update')
+		          )
+		       ) AS associated_candidates
+		FROM dispatch d`,
+		dispatchID,
+	).Scan(&action, &activityID, &broadcastCandidates, &associatedCandidates)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return
+		}
+		log.Printf("live_activity_scoped_update_fanout_shadow_error dispatch_id=%s error=%v", dispatchID, err)
+		return
+	}
+
+	log.Printf(
+		"live_activity_scoped_update_fanout_shadow dispatch_id=%s action=%s activity_id=%s broadcast_candidates=%d associated_candidates=%d",
+		dispatchID,
+		action,
+		activityID,
+		broadcastCandidates,
+		associatedCandidates,
+	)
+}
+
 type laOutcomeDelta struct {
 	success int
 	failure int
+}
+
+type laTokenActivityAssociation struct {
+	tokenID    string
+	activityID string
+	source     string
 }
 
 func (s *PostgresStore) CompleteLADispatchEnqueue(ctx context.Context, dispatchID string, totalCount int) error {
@@ -656,8 +848,11 @@ func (s *PostgresStore) ApplyLAOutcomeBatch(ctx context.Context, outcomes []mode
 	}
 	defer tx.Rollback()
 
-	deltas, invalidTokenIDs := summarizeLAOutcomes(outcomes)
+	deltas, invalidTokenIDs, tokenActivities := summarizeLAOutcomes(outcomes)
 	if err := invalidateLATokensTx(ctx, tx, invalidTokenIDs); err != nil {
+		return err
+	}
+	if err := associateLATokensTx(ctx, tx, tokenActivities, time.Now().UTC()); err != nil {
 		return err
 	}
 
@@ -701,9 +896,10 @@ func (s *PostgresStore) completeEmptyLADispatch(ctx context.Context, dispatchID 
 	return nil
 }
 
-func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelta, map[string]struct{}) {
+func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelta, map[string]struct{}, []laTokenActivityAssociation) {
 	deltas := make(map[string]laOutcomeDelta)
 	invalidTokenIDs := make(map[string]struct{})
+	tokenActivities := make([]laTokenActivityAssociation, 0)
 
 	for _, outcome := range outcomes {
 		dispatchID := outcome.Receipt.JobID
@@ -711,6 +907,17 @@ func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelt
 		switch outcome.Receipt.Status {
 		case model.DeliveryStatusSuccess:
 			delta.success++
+			if outcome.Task.Job != nil &&
+				outcome.Task.Job.LAAction == model.LiveActivityActionStart &&
+				outcome.Task.Job.LAActivityID != "" &&
+				outcome.Task.Target.Platform == model.FCM &&
+				outcome.Receipt.TokenID != "" {
+				tokenActivities = append(tokenActivities, laTokenActivityAssociation{
+					tokenID:    outcome.Receipt.TokenID,
+					activityID: outcome.Task.Job.LAActivityID,
+					source:     "start_dispatch",
+				})
+			}
 		case model.DeliveryStatusFailed:
 			delta.failure++
 			if isLAInvalidToken(outcome.Receipt.StatusReason) {
@@ -720,7 +927,7 @@ func summarizeLAOutcomes(outcomes []model.SendOutcome) (map[string]laOutcomeDelt
 		deltas[dispatchID] = delta
 	}
 
-	return deltas, invalidTokenIDs
+	return deltas, invalidTokenIDs, tokenActivities
 }
 
 func invalidateLATokensTx(ctx context.Context, tx *sql.Tx, invalidTokenIDs map[string]struct{}) error {
@@ -741,6 +948,33 @@ func invalidateLATokensTx(ctx context.Context, tx *sql.Tx, invalidTokenIDs map[s
 		pq.Array(tokenIDs),
 	); err != nil {
 		return fmt.Errorf("error invalidating LA tokens: %w", err)
+	}
+	return nil
+}
+
+func associateLATokensTx(ctx context.Context, tx *sql.Tx, associations []laTokenActivityAssociation, lastSeenAt time.Time) error {
+	if len(associations) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(associations))
+	for _, association := range associations {
+		key := association.activityID + "\x00" + association.tokenID
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		if err := associateLiveActivityTokenTx(
+			ctx,
+			tx,
+			association.activityID,
+			association.tokenID,
+			lastSeenAt,
+			association.source,
+		); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/storage/live_activity_postgres_test.go
+++ b/internal/storage/live_activity_postgres_test.go
@@ -13,6 +13,7 @@ func TestIsLAInvalidToken(t *testing.T) {
 	}{
 		{reason: "APNs error: 400 Bad Request (reason: BadDeviceToken)", want: true},
 		{reason: "APNs error: 410 Gone (reason: Unregistered)", want: true},
+		{reason: "APNs error: 400 Bad Request (reason: ExpiredToken)", want: true},
 		{reason: "FCM error: registration-token-not-registered", want: true},
 		{reason: "FCM error: backend unavailable", want: false},
 		{reason: "rate limited after 3 retries: 429 Too Many Requests", want: false},
@@ -31,6 +32,15 @@ func TestIsLAInvalidToken(t *testing.T) {
 func TestSummarizeLAOutcomes(t *testing.T) {
 	outcomes := []model.SendOutcome{
 		{
+			Task: model.SendTask{
+				Target: model.SendTarget{
+					Platform: model.FCM,
+				},
+				Job: &model.JobItem{
+					LAAction:     model.LiveActivityActionStart,
+					LAActivityID: "activity-1",
+				},
+			},
 			Receipt: model.DeliveryReceipt{
 				JobID:   "dispatch-1",
 				TokenID: "token-1",
@@ -63,7 +73,7 @@ func TestSummarizeLAOutcomes(t *testing.T) {
 		},
 	}
 
-	deltas, invalidTokenIDs := summarizeLAOutcomes(outcomes)
+	deltas, invalidTokenIDs, tokenActivities := summarizeLAOutcomes(outcomes)
 
 	if got := deltas["dispatch-1"]; got.success != 1 || got.failure != 2 {
 		t.Fatalf("dispatch-1 delta = %+v, want 1 success / 2 failure", got)
@@ -79,5 +89,11 @@ func TestSummarizeLAOutcomes(t *testing.T) {
 	}
 	if _, ok := invalidTokenIDs["token-3"]; ok {
 		t.Fatalf("token-3 generic failure should not be marked invalid")
+	}
+	if len(tokenActivities) != 1 {
+		t.Fatalf("tokenActivities length = %d, want 1", len(tokenActivities))
+	}
+	if tokenActivities[0].tokenID != "token-1" || tokenActivities[0].activityID != "activity-1" || tokenActivities[0].source != "start_dispatch" {
+		t.Fatalf("tokenActivities[0] = %+v", tokenActivities[0])
 	}
 }

--- a/internal/storage/live_activity_postgres_test.go
+++ b/internal/storage/live_activity_postgres_test.go
@@ -32,15 +32,6 @@ func TestIsLAInvalidToken(t *testing.T) {
 func TestSummarizeLAOutcomes(t *testing.T) {
 	outcomes := []model.SendOutcome{
 		{
-			Task: model.SendTask{
-				Target: model.SendTarget{
-					Platform: model.FCM,
-				},
-				Job: &model.JobItem{
-					LAAction:     model.LiveActivityActionStart,
-					LAActivityID: "activity-1",
-				},
-			},
 			Receipt: model.DeliveryReceipt{
 				JobID:   "dispatch-1",
 				TokenID: "token-1",
@@ -73,7 +64,7 @@ func TestSummarizeLAOutcomes(t *testing.T) {
 		},
 	}
 
-	deltas, invalidTokenIDs, tokenActivities := summarizeLAOutcomes(outcomes)
+	deltas, invalidTokenIDs := summarizeLAOutcomes(outcomes)
 
 	if got := deltas["dispatch-1"]; got.success != 1 || got.failure != 2 {
 		t.Fatalf("dispatch-1 delta = %+v, want 1 success / 2 failure", got)
@@ -89,11 +80,5 @@ func TestSummarizeLAOutcomes(t *testing.T) {
 	}
 	if _, ok := invalidTokenIDs["token-3"]; ok {
 		t.Fatalf("token-3 generic failure should not be marked invalid")
-	}
-	if len(tokenActivities) != 1 {
-		t.Fatalf("tokenActivities length = %d, want 1", len(tokenActivities))
-	}
-	if tokenActivities[0].tokenID != "token-1" || tokenActivities[0].activityID != "activity-1" || tokenActivities[0].source != "start_dispatch" {
-		t.Fatalf("tokenActivities[0] = %+v", tokenActivities[0])
 	}
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -92,6 +92,7 @@ type LiveActivityToken struct {
 	Platform      model.Platform
 	TokenType     model.LiveActivityTokenType
 	Token         string
+	ActivityID    string
 	CreatedAt     time.Time
 	LastSeenAt    time.Time
 	ExpiresAt     *time.Time


### PR DESCRIPTION
## Summary

Implements the Pushboy side of activity-scoped Live Activity update-token fanout.

- Accepts `activityId` on `/v1/live-activity/tokens`.
- Stores token/activity associations in `live_activity_token_activities`.
- Keeps `start` fanout as topic/user broadcast.
- Gates `update` and `end` fanout by `LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT`, default off.
- Emits shadow metrics while scoped fanout is off so broadcast candidate counts can be compared with activity-associated candidates.
- Associates FCM Live Activity tokens to the activity after successful start dispatch.
- Treats APNS `ExpiredToken` as an invalid LA token outcome.

## Deployment notes

Leave `LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT=false` at first. Deploy this branch to capture associations and shadow metrics, then enable scoped fanout only after associated candidate counts match expectations for current sessions.

Refs #42.

## Validation

- `go test ./...`
- `git diff --check`
