### PR TITLE
Fix LA scoped fanout while start is pending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,3 @@ FCM_KEY_PATH=keys/service-account.json
 # ===========================================
 # Users created by the API are automatically subscribed to this topic.
 BROADCAST_TOPIC_NAME=broadcast
-
-# Gate Live Activity update/end fanout to tokens associated with the job activityId.
-# Keep this false until shadow metrics show associated candidate counts are safe.
-LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT=false

--- a/internal/storage/live_activity_fanout_test.go
+++ b/internal/storage/live_activity_fanout_test.go
@@ -26,9 +26,7 @@ func init() {
 	sql.Register(liveActivityFanoutTestDriverName, liveActivityFanoutDriver{})
 }
 
-func TestGetLATokenBatchForDispatchDefersScopedFilteringWhileStartPending(t *testing.T) {
-	t.Setenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT", "true")
-
+func TestGetLATokenBatchForDispatchDefersAssociationFilteringWhileStartPending(t *testing.T) {
 	scenario := &liveActivityFanoutScenario{
 		scope: liveActivityDispatchFanoutScope{
 			action:               model.LiveActivityActionUpdate,
@@ -53,8 +51,6 @@ func TestGetLATokenBatchForDispatchDefersScopedFilteringWhileStartPending(t *tes
 }
 
 func TestGetLATokenBatchForDispatchRequiresAssociationAfterStartCompletes(t *testing.T) {
-	t.Setenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT", "true")
-
 	scenario := &liveActivityFanoutScenario{
 		scope: liveActivityDispatchFanoutScope{
 			action:     model.LiveActivityActionUpdate,
@@ -78,8 +74,6 @@ func TestGetLATokenBatchForDispatchRequiresAssociationAfterStartCompletes(t *tes
 }
 
 func TestGetLATokenBatchForDispatchReturnsAssociatedTokensAfterStartCompletes(t *testing.T) {
-	t.Setenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT", "true")
-
 	scenario := &liveActivityFanoutScenario{
 		scope: liveActivityDispatchFanoutScope{
 			action:     model.LiveActivityActionUpdate,

--- a/internal/storage/live_activity_fanout_test.go
+++ b/internal/storage/live_activity_fanout_test.go
@@ -1,0 +1,252 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mithileshchellappan/pushboy/internal/model"
+)
+
+const liveActivityFanoutTestDriverName = "pushboy_la_fanout_test"
+
+var (
+	liveActivityFanoutScenarioID int64
+	liveActivityFanoutScenarios  sync.Map
+)
+
+func init() {
+	sql.Register(liveActivityFanoutTestDriverName, liveActivityFanoutDriver{})
+}
+
+func TestGetLATokenBatchForDispatchDefersScopedFilteringWhileStartPending(t *testing.T) {
+	t.Setenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT", "true")
+
+	scenario := &liveActivityFanoutScenario{
+		scope: liveActivityDispatchFanoutScope{
+			action:               model.LiveActivityActionUpdate,
+			activityID:           "activity-1",
+			userID:               "user-1",
+			startDispatchPending: true,
+		},
+		tokenRows: liveActivityFanoutTokenRows(t),
+	}
+	store := newLiveActivityFanoutTestStore(t, scenario)
+
+	batch, err := store.GetLATokenBatchForDispatch(context.Background(), "dispatch-update", "", 10)
+	if err != nil {
+		t.Fatalf("GetLATokenBatchForDispatch error = %v", err)
+	}
+	if len(batch.Tokens) != 1 {
+		t.Fatalf("tokens len = %d, want 1", len(batch.Tokens))
+	}
+	if got := scenario.requireActivityAssociationArgs(); len(got) != 1 || got[0] {
+		t.Fatalf("require activity association args = %v, want [false]", got)
+	}
+}
+
+func TestGetLATokenBatchForDispatchRequiresAssociationAfterStartCompletes(t *testing.T) {
+	t.Setenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT", "true")
+
+	scenario := &liveActivityFanoutScenario{
+		scope: liveActivityDispatchFanoutScope{
+			action:     model.LiveActivityActionUpdate,
+			activityID: "activity-1",
+			userID:     "user-1",
+		},
+		tokenRows: liveActivityFanoutTokenRows(t),
+	}
+	store := newLiveActivityFanoutTestStore(t, scenario)
+
+	batch, err := store.GetLATokenBatchForDispatch(context.Background(), "dispatch-update", "", 10)
+	if err != nil {
+		t.Fatalf("GetLATokenBatchForDispatch error = %v", err)
+	}
+	if len(batch.Tokens) != 0 {
+		t.Fatalf("tokens len = %d, want 0 for unassociated token after start completion", len(batch.Tokens))
+	}
+	if got := scenario.requireActivityAssociationArgs(); len(got) != 1 || !got[0] {
+		t.Fatalf("require activity association args = %v, want [true]", got)
+	}
+}
+
+func TestGetLATokenBatchForDispatchReturnsAssociatedTokensAfterStartCompletes(t *testing.T) {
+	t.Setenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT", "true")
+
+	scenario := &liveActivityFanoutScenario{
+		scope: liveActivityDispatchFanoutScope{
+			action:     model.LiveActivityActionUpdate,
+			activityID: "activity-1",
+			userID:     "user-1",
+		},
+		tokenRows:           liveActivityFanoutTokenRows(t),
+		tokenHasAssociation: true,
+	}
+	store := newLiveActivityFanoutTestStore(t, scenario)
+
+	batch, err := store.GetLATokenBatchForDispatch(context.Background(), "dispatch-update", "", 10)
+	if err != nil {
+		t.Fatalf("GetLATokenBatchForDispatch error = %v", err)
+	}
+	if len(batch.Tokens) != 1 {
+		t.Fatalf("tokens len = %d, want 1", len(batch.Tokens))
+	}
+	if got := scenario.requireActivityAssociationArgs(); len(got) != 1 || !got[0] {
+		t.Fatalf("require activity association args = %v, want [true]", got)
+	}
+}
+
+type liveActivityFanoutScenario struct {
+	mu                         sync.Mutex
+	scope                      liveActivityDispatchFanoutScope
+	tokenRows                  [][]driver.Value
+	tokenHasAssociation        bool
+	requireAssociationRequests []bool
+}
+
+func (s *liveActivityFanoutScenario) requireActivityAssociationArgs() []bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	args := make([]bool, len(s.requireAssociationRequests))
+	copy(args, s.requireAssociationRequests)
+	return args
+}
+
+func newLiveActivityFanoutTestStore(t *testing.T, scenario *liveActivityFanoutScenario) *PostgresStore {
+	t.Helper()
+
+	id := fmt.Sprintf("%d", atomic.AddInt64(&liveActivityFanoutScenarioID, 1))
+	liveActivityFanoutScenarios.Store(id, scenario)
+	t.Cleanup(func() {
+		liveActivityFanoutScenarios.Delete(id)
+	})
+
+	db, err := sql.Open(liveActivityFanoutTestDriverName, id)
+	if err != nil {
+		t.Fatalf("open test sql driver: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("close test db: %v", err)
+		}
+	})
+
+	return &PostgresStore{db: db}
+}
+
+func liveActivityFanoutTokenRows(t *testing.T) [][]driver.Value {
+	t.Helper()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	return [][]driver.Value{
+		{
+			"token-1",
+			"user-1",
+			string(model.FCM),
+			string(model.LiveActivityTokenTypeUpdate),
+			"fcm-token",
+			now,
+			now,
+			nil,
+			nil,
+		},
+	}
+}
+
+type liveActivityFanoutDriver struct{}
+
+func (liveActivityFanoutDriver) Open(name string) (driver.Conn, error) {
+	raw, ok := liveActivityFanoutScenarios.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unknown live activity fanout scenario %q", name)
+	}
+	return &liveActivityFanoutConn{scenario: raw.(*liveActivityFanoutScenario)}, nil
+}
+
+type liveActivityFanoutConn struct {
+	scenario *liveActivityFanoutScenario
+}
+
+func (c *liveActivityFanoutConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("Prepare is not implemented")
+}
+
+func (c *liveActivityFanoutConn) Close() error {
+	return nil
+}
+
+func (c *liveActivityFanoutConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("Begin is not implemented")
+}
+
+func (c *liveActivityFanoutConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	switch {
+	case strings.Contains(query, "SELECT lad.action") && strings.Contains(query, "start_dispatch_pending"):
+		scope := c.scenario.scope
+		return &liveActivityFanoutRows{
+			columns: []string{"action", "activity_id", "user_id", "topic_id", "start_dispatch_pending"},
+			values: [][]driver.Value{{
+				string(scope.action),
+				scope.activityID,
+				scope.userID,
+				scope.topicID,
+				scope.startDispatchPending,
+			}},
+		}, nil
+	case strings.Contains(query, "SELECT lat.id"):
+		if len(args) != 7 {
+			return nil, fmt.Errorf("token query args len = %d, want 7", len(args))
+		}
+		requireAssociation, ok := args[4].Value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("require association arg type = %T, want bool", args[4].Value)
+		}
+		c.scenario.mu.Lock()
+		c.scenario.requireAssociationRequests = append(c.scenario.requireAssociationRequests, requireAssociation)
+		c.scenario.mu.Unlock()
+
+		values := c.scenario.tokenRows
+		if requireAssociation && !c.scenario.tokenHasAssociation {
+			values = nil
+		}
+		return &liveActivityFanoutRows{
+			columns: []string{"id", "user_id", "platform", "token_type", "token", "created_at", "last_seen_at", "expires_at", "invalidated_at"},
+			values:  values,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", query)
+	}
+}
+
+type liveActivityFanoutRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *liveActivityFanoutRows) Columns() []string {
+	return r.columns
+}
+
+func (r *liveActivityFanoutRows) Close() error {
+	return nil
+}
+
+func (r *liveActivityFanoutRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+var _ driver.QueryerContext = (*liveActivityFanoutConn)(nil)

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"strings"
 	"time"
 
@@ -122,11 +120,6 @@ func laConstraint(err error) string {
 	return ""
 }
 
-func liveActivityScopedUpdateFanoutEnabled() bool {
-	value := strings.TrimSpace(os.Getenv("LIVE_ACTIVITY_SCOPED_UPDATE_FANOUT"))
-	return value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes")
-}
-
 type liveActivityDispatchFanoutScope struct {
 	action               model.LiveActivityAction
 	activityID           string
@@ -135,9 +128,8 @@ type liveActivityDispatchFanoutScope struct {
 	startDispatchPending bool
 }
 
-func (scope liveActivityDispatchFanoutScope) requiresActivityAssociation(scopedFanout bool) bool {
-	return scopedFanout &&
-		scope.action != model.LiveActivityActionStart &&
+func (scope liveActivityDispatchFanoutScope) requiresActivityAssociation() bool {
+	return scope.action != model.LiveActivityActionStart &&
 		!scope.startDispatchPending
 }
 
@@ -645,11 +637,6 @@ func (s *PostgresStore) getLADispatchFanoutScope(ctx context.Context, dispatchID
 }
 
 func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatchID string, cursor string, batchSize int) (*LiveActivityTokenBatch, error) {
-	scopedFanout := liveActivityScopedUpdateFanoutEnabled()
-	if cursor == "" && !scopedFanout {
-		s.logLAScopedFanoutShadow(ctx, dispatchID)
-	}
-
 	scope, err := s.getLADispatchFanoutScope(ctx, dispatchID)
 	if err != nil {
 		return nil, err
@@ -698,7 +685,7 @@ func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatch
 		cursor,
 		scope.userID,
 		scope.topicID,
-		scope.requiresActivityAssociation(scopedFanout),
+		scope.requiresActivityAssociation(),
 		scope.activityID,
 		batchSize+1,
 	)
@@ -726,73 +713,6 @@ func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatch
 		batch.NextCursor = tokens[batchSize-1].ID
 	}
 	return batch, nil
-}
-
-func (s *PostgresStore) logLAScopedFanoutShadow(ctx context.Context, dispatchID string) {
-	var action string
-	var activityID string
-	var broadcastCandidates int
-	var associatedCandidates int
-
-	err := s.db.QueryRowContext(
-		ctx,
-		`WITH dispatch AS (
-			 SELECT lad.action, laj.activity_id, laj.user_id, laj.topic_id
-			 FROM live_activity_dispatches lad
-			 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
-			 WHERE lad.id = $1
-			   AND lad.action <> 'start'
-		),
-		scoped_tokens AS (
-			 SELECT d.activity_id, lat.id
-			 FROM dispatch d
-			 JOIN live_activity_tokens lat
-			   ON lat.invalidated_at IS NULL
-			  AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
-			  AND (
-				(lat.platform = 'apns' AND lat.token_type = 'update')
-				OR
-				(lat.platform = 'fcm' AND lat.token_type = 'update')
-			  )
-			 WHERE (d.user_id IS NOT NULL AND lat.user_id = d.user_id)
-			    OR (
-				d.topic_id IS NOT NULL
-				AND lat.user_id IN (
-					SELECT user_id
-					FROM live_activity_user_topic_subscriptions
-					WHERE topic_id = d.topic_id
-				)
-			    )
-		)
-		SELECT d.action,
-		       d.activity_id,
-		       (SELECT COUNT(*) FROM scoped_tokens) AS broadcast_candidates,
-		       (
-			SELECT COUNT(*)
-			FROM scoped_tokens st
-			JOIN live_activity_token_activities lata
-			  ON lata.token_id = st.id
-			 AND lata.activity_id = st.activity_id
-		       ) AS associated_candidates
-		FROM dispatch d`,
-		dispatchID,
-	).Scan(&action, &activityID, &broadcastCandidates, &associatedCandidates)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return
-		}
-		log.Printf("live_activity_scoped_update_fanout_shadow_error dispatch_id=%s error=%v", dispatchID, err)
-		return
-	}
-
-	log.Printf(
-		"live_activity_scoped_update_fanout_shadow dispatch_id=%s action=%s activity_id=%s broadcast_candidates=%d associated_candidates=%d",
-		dispatchID,
-		action,
-		activityID,
-		broadcastCandidates,
-		associatedCandidates,
-	)
 }
 
 type laOutcomeDelta struct {

--- a/internal/storage/live_activity_postgres.go
+++ b/internal/storage/live_activity_postgres.go
@@ -127,6 +127,20 @@ func liveActivityScopedUpdateFanoutEnabled() bool {
 	return value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes")
 }
 
+type liveActivityDispatchFanoutScope struct {
+	action               model.LiveActivityAction
+	activityID           string
+	userID               string
+	topicID              string
+	startDispatchPending bool
+}
+
+func (scope liveActivityDispatchFanoutScope) requiresActivityAssociation(scopedFanout bool) bool {
+	return scopedFanout &&
+		scope.action != model.LiveActivityActionStart &&
+		!scope.startDispatchPending
+}
+
 func (s *PostgresStore) UpsertLiveActivityToken(ctx context.Context, token *LiveActivityToken) (*LiveActivityToken, error) {
 	now := time.Now().UTC()
 	if token.ID == "" {
@@ -598,58 +612,94 @@ func (s *PostgresStore) UpdateLADispatchStatus(ctx context.Context, dispatchID s
 	return nil
 }
 
+func (s *PostgresStore) getLADispatchFanoutScope(ctx context.Context, dispatchID string) (*liveActivityDispatchFanoutScope, error) {
+	var action string
+	scope := &liveActivityDispatchFanoutScope{}
+	err := s.db.QueryRowContext(
+		ctx,
+		`SELECT lad.action,
+		        laj.activity_id,
+		        COALESCE(laj.user_id, ''),
+		        COALESCE(laj.topic_id, ''),
+		        EXISTS (
+			SELECT 1
+			FROM live_activity_dispatches start_lad
+			WHERE start_lad.live_activity_job_id = laj.id
+			  AND start_lad.action = 'start'
+			  AND start_lad.status IN ('QUEUED', 'IN_PROGRESS', 'DISPATCHED')
+		        ) AS start_dispatch_pending
+		 FROM live_activity_dispatches lad
+		 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
+		 WHERE lad.id = $1`,
+		dispatchID,
+	).Scan(&action, &scope.activityID, &scope.userID, &scope.topicID, &scope.startDispatchPending)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, Errors.NotFound
+		}
+		return nil, fmt.Errorf("error loading LA dispatch fanout scope: %w", err)
+	}
+
+	scope.action = model.LiveActivityAction(action)
+	return scope, nil
+}
+
 func (s *PostgresStore) GetLATokenBatchForDispatch(ctx context.Context, dispatchID string, cursor string, batchSize int) (*LiveActivityTokenBatch, error) {
 	scopedFanout := liveActivityScopedUpdateFanoutEnabled()
 	if cursor == "" && !scopedFanout {
 		s.logLAScopedFanoutShadow(ctx, dispatchID)
 	}
 
-	activityFilter := ""
-	if scopedFanout {
-		activityFilter = `
-	   AND (
-		lad.action = 'start'
-		OR EXISTS (
-			SELECT 1
-			FROM live_activity_token_activities lata
-			WHERE lata.activity_id = laj.activity_id
-			  AND lata.token_id = lat.id
-		)
-	   )`
+	scope, err := s.getLADispatchFanoutScope(ctx, dispatchID)
+	if err != nil {
+		return nil, err
 	}
 
-	query := `SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
-	 FROM live_activity_dispatches lad
-	 JOIN live_activity_jobs laj ON laj.id = lad.live_activity_job_id
-	 JOIN live_activity_tokens lat
-	   ON lat.invalidated_at IS NULL
-	  AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
-	  AND (
-		(lat.platform = 'apns' AND lat.token_type = CASE WHEN lad.action = 'start' THEN 'start' ELSE 'update' END)
-		OR
-		(lat.platform = 'fcm' AND lat.token_type = 'update')
-	  )
-	 WHERE lad.id = $1
-	   AND lat.id > $2
-	   AND (
-		(laj.user_id IS NOT NULL AND lat.user_id = laj.user_id)
-		OR (
-			laj.topic_id IS NOT NULL
-			AND lat.user_id IN (
-				SELECT user_id
-				FROM live_activity_user_topic_subscriptions
-				WHERE topic_id = laj.topic_id
-			)
-		)
-	   )` + activityFilter + `
-	 ORDER BY lat.id
-	 LIMIT $3`
+	apnsTokenType := model.LiveActivityTokenTypeUpdate
+	if scope.action == model.LiveActivityActionStart {
+		apnsTokenType = model.LiveActivityTokenTypeStart
+	}
 
 	rows, err := s.db.QueryContext(
 		ctx,
-		query,
-		dispatchID,
+		`SELECT lat.id, lat.user_id, lat.platform, lat.token_type, lat.token, lat.created_at, lat.last_seen_at, lat.expires_at, lat.invalidated_at
+		 FROM live_activity_tokens lat
+		 WHERE lat.invalidated_at IS NULL
+		   AND (lat.expires_at IS NULL OR lat.expires_at > NOW())
+		   AND (
+			(lat.platform = 'apns' AND lat.token_type = $1)
+			OR
+			(lat.platform = 'fcm' AND lat.token_type = 'update')
+		   )
+		   AND lat.id > $2
+		   AND (
+			($3 <> '' AND lat.user_id = $3)
+			OR (
+				$4 <> ''
+				AND lat.user_id IN (
+					SELECT user_id
+					FROM live_activity_user_topic_subscriptions
+					WHERE topic_id = $4
+				)
+			)
+		   )
+		   AND (
+			NOT $5
+			OR EXISTS (
+				SELECT 1
+				FROM live_activity_token_activities lata
+				WHERE lata.activity_id = $6
+				  AND lata.token_id = lat.id
+			)
+		   )
+		 ORDER BY lat.id
+		 LIMIT $7`,
+		apnsTokenType,
 		cursor,
+		scope.userID,
+		scope.topicID,
+		scope.requiresActivityAssociation(scopedFanout),
+		scope.activityID,
 		batchSize+1,
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
- load LA dispatch fanout scope before batching tokens
- defer activity-association filtering while the corresponding start dispatch is still queued, in progress, or dispatched
- add focused storage tests for pending and completed start fanout behavior

## Testing
- go test ./internal/storage
- go test ./...